### PR TITLE
refactor amount type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bincode = { version = "1.3.3", default-features = false }
 sha3 = "^0.10"
 hex-literal = "^0.3"
 serde_json = "1.0.61"
+derive_more = "0.99.17"
 
 # curves
 ark-bls12-381 = { version = "0.3.0", default-features = false, features = ["curve"], optional = true }

--- a/src/bench_utils/mod.rs
+++ b/src/bench_utils/mod.rs
@@ -275,9 +275,9 @@ pub fn get_builder_freeze<'a>(
     num_inputs: usize,
     tree_depth: u8,
 ) -> FreezeParamsBuilder<'a> {
-    let input_amounts = vec![Amount(15_u128); num_inputs - 1];
-    let fee_input_amount = Amount(10);
-    let fee = Amount(5);
+    let input_amounts = vec![Amount::from(15_u128); num_inputs - 1];
+    let fee_input_amount = Amount::from(10u64);
+    let fee = Amount::from(5u64);
 
     FreezeParamsBuilder::new(
         tree_depth,
@@ -296,9 +296,9 @@ pub fn get_builder_mint<'a, R: RngCore + CryptoRng>(
     auditor_keypair: &'a AuditorKeyPair,
     tree_depth: u8,
 ) -> MintParamsBuilder<'a> {
-    let input_amount = Amount(10);
-    let fee = Amount(4);
-    let mint_amount = Amount(35);
+    let input_amount = Amount::from(10u64);
+    let fee = Amount::from(4u64);
+    let mint_amount = Amount::from(35u64);
 
     MintParamsBuilder::new(
         rng,
@@ -320,12 +320,12 @@ pub fn get_builder_transfer(
 ) -> TransferParamsBuilder {
     let cred_expiry = 9999;
 
-    let amount_input = Amount(1);
+    let amount_input = Amount::from(1u64);
     let amount_inputs = vec![amount_input; num_inputs - 1];
 
     // Ensure that "sum of input amounts == sum of output amounts"
-    let mut amount_outputs: Vec<Amount> = vec![Amount((num_inputs - 1) as u128)];
-    amount_outputs.extend(vec![Amount(0); num_outputs - 2].iter());
+    let mut amount_outputs: Vec<Amount> = vec![Amount::from((num_inputs - 1) as u128)];
+    amount_outputs.extend(vec![Amount::from(0u64); num_outputs - 2].iter());
 
     TransferParamsBuilder::new_non_native(
         num_inputs,
@@ -333,7 +333,7 @@ pub fn get_builder_transfer(
         Some(tree_depth),
         user_keypairs.iter().collect(),
     )
-    .set_input_amounts(Amount(30), &amount_inputs)
-    .set_output_amounts(Amount(29), &amount_outputs)
+    .set_input_amounts(Amount::from(30u64), &amount_inputs)
+    .set_output_amounts(Amount::from(29u64), &amount_outputs)
     .set_input_creds(cred_expiry)
 }

--- a/src/bench_utils/mod.rs
+++ b/src/bench_utils/mod.rs
@@ -12,6 +12,7 @@
 #![allow(missing_docs)]
 use crate::{
     keys::{AuditorKeyPair, FreezerKeyPair, UserKeyPair},
+    structs::AmountValue,
     utils::params_builder::{FreezeParamsBuilder, MintParamsBuilder, TransferParamsBuilder},
 };
 use ark_serialize::CanonicalSerialize;
@@ -274,9 +275,9 @@ pub fn get_builder_freeze<'a>(
     num_inputs: usize,
     tree_depth: u8,
 ) -> FreezeParamsBuilder<'a> {
-    let input_amounts = vec![15_u64; num_inputs - 1];
-    let fee_input_amount = 10;
-    let fee = 5;
+    let input_amounts = vec![AmountValue(15_u128); num_inputs - 1];
+    let fee_input_amount = AmountValue(10);
+    let fee = AmountValue(5);
 
     FreezeParamsBuilder::new(
         tree_depth,
@@ -295,9 +296,9 @@ pub fn get_builder_mint<'a, R: RngCore + CryptoRng>(
     auditor_keypair: &'a AuditorKeyPair,
     tree_depth: u8,
 ) -> MintParamsBuilder<'a> {
-    let input_amount = 10;
-    let fee = 4;
-    let mint_amount = 35;
+    let input_amount = AmountValue(10);
+    let fee = AmountValue(4);
+    let mint_amount = AmountValue(35);
 
     MintParamsBuilder::new(
         rng,
@@ -319,12 +320,12 @@ pub fn get_builder_transfer(
 ) -> TransferParamsBuilder {
     let cred_expiry = 9999;
 
-    let amount_input = 1;
+    let amount_input = AmountValue(1);
     let amount_inputs = vec![amount_input; num_inputs - 1];
 
     // Ensure that "sum of input amounts == sum of output amounts"
-    let mut amount_outputs = vec![amount_input * ((num_inputs - 1) as u64)];
-    amount_outputs.extend(vec![0; num_outputs - 2].iter());
+    let mut amount_outputs: Vec<AmountValue> = vec![AmountValue((num_inputs - 1) as u128)];
+    amount_outputs.extend(vec![AmountValue(0); num_outputs - 2].iter());
 
     TransferParamsBuilder::new_non_native(
         num_inputs,
@@ -332,7 +333,7 @@ pub fn get_builder_transfer(
         Some(tree_depth),
         user_keypairs.iter().collect(),
     )
-    .set_input_amounts(30, &amount_inputs)
-    .set_output_amounts(29, &amount_outputs)
+    .set_input_amounts(AmountValue(30), &amount_inputs)
+    .set_output_amounts(AmountValue(29), &amount_outputs)
     .set_input_creds(cred_expiry)
 }

--- a/src/bench_utils/mod.rs
+++ b/src/bench_utils/mod.rs
@@ -12,7 +12,7 @@
 #![allow(missing_docs)]
 use crate::{
     keys::{AuditorKeyPair, FreezerKeyPair, UserKeyPair},
-    structs::AmountValue,
+    structs::Amount,
     utils::params_builder::{FreezeParamsBuilder, MintParamsBuilder, TransferParamsBuilder},
 };
 use ark_serialize::CanonicalSerialize;
@@ -275,9 +275,9 @@ pub fn get_builder_freeze<'a>(
     num_inputs: usize,
     tree_depth: u8,
 ) -> FreezeParamsBuilder<'a> {
-    let input_amounts = vec![AmountValue(15_u128); num_inputs - 1];
-    let fee_input_amount = AmountValue(10);
-    let fee = AmountValue(5);
+    let input_amounts = vec![Amount(15_u128); num_inputs - 1];
+    let fee_input_amount = Amount(10);
+    let fee = Amount(5);
 
     FreezeParamsBuilder::new(
         tree_depth,
@@ -296,9 +296,9 @@ pub fn get_builder_mint<'a, R: RngCore + CryptoRng>(
     auditor_keypair: &'a AuditorKeyPair,
     tree_depth: u8,
 ) -> MintParamsBuilder<'a> {
-    let input_amount = AmountValue(10);
-    let fee = AmountValue(4);
-    let mint_amount = AmountValue(35);
+    let input_amount = Amount(10);
+    let fee = Amount(4);
+    let mint_amount = Amount(35);
 
     MintParamsBuilder::new(
         rng,
@@ -320,12 +320,12 @@ pub fn get_builder_transfer(
 ) -> TransferParamsBuilder {
     let cred_expiry = 9999;
 
-    let amount_input = AmountValue(1);
+    let amount_input = Amount(1);
     let amount_inputs = vec![amount_input; num_inputs - 1];
 
     // Ensure that "sum of input amounts == sum of output amounts"
-    let mut amount_outputs: Vec<AmountValue> = vec![AmountValue((num_inputs - 1) as u128)];
-    amount_outputs.extend(vec![AmountValue(0); num_outputs - 2].iter());
+    let mut amount_outputs: Vec<Amount> = vec![Amount((num_inputs - 1) as u128)];
+    amount_outputs.extend(vec![Amount(0); num_outputs - 2].iter());
 
     TransferParamsBuilder::new_non_native(
         num_inputs,
@@ -333,7 +333,7 @@ pub fn get_builder_transfer(
         Some(tree_depth),
         user_keypairs.iter().collect(),
     )
-    .set_input_amounts(AmountValue(30), &amount_inputs)
-    .set_output_amounts(AmountValue(29), &amount_outputs)
+    .set_input_amounts(Amount(30), &amount_inputs)
+    .set_output_amounts(Amount(29), &amount_outputs)
     .set_input_creds(cred_expiry)
 }

--- a/src/circuit/freeze.rs
+++ b/src/circuit/freeze.rs
@@ -261,7 +261,7 @@ mod tests {
     use crate::{
         keys::{FreezerKeyPair, UserKeyPair, UserPubKey},
         structs::{
-            AmountValue, AssetCode, AssetDefinition, AssetPolicy, FreezeFlag, Nullifier,
+            Amount, AssetCode, AssetDefinition, AssetPolicy, FreezeFlag, Nullifier,
             RecordCommitment,
         },
         utils::params_builder::FreezeParamsBuilder,
@@ -284,7 +284,7 @@ mod tests {
         let pub_input = FreezePublicInput {
             merkle_root: NodeValue::from_scalar(BaseField::from(20u8)),
             native_asset_code: AssetCode::native(),
-            fee: AmountValue(30u128),
+            fee: Amount(30u128),
             input_nullifiers,
             output_commitments,
         };
@@ -322,9 +322,9 @@ mod tests {
         let tree_depth = 2;
         let fee_keypair = UserKeyPair::generate(rng);
         let freezing_keypair = FreezerKeyPair::generate(rng);
-        let input_amounts = vec![AmountValue(20), AmountValue(30)];
-        let fee_input_amount = AmountValue(10);
-        let fee = AmountValue(5);
+        let input_amounts = vec![Amount(20), Amount(30)];
+        let fee_input_amount = Amount(10);
+        let fee = Amount(5);
         let builder = FreezeParamsBuilder::new(
             tree_depth,
             &input_amounts,
@@ -339,7 +339,7 @@ mod tests {
         // wrong fee balance
         {
             let mut bad_pub_input = pub_input.clone();
-            bad_pub_input.fee = AmountValue(3);
+            bad_pub_input.fee = Amount(3);
             check_freezing_circuit(&witness, &bad_pub_input, false)?;
         }
 
@@ -360,7 +360,7 @@ mod tests {
         // inconsistent amount
         {
             let mut bad_witness = witness.clone();
-            bad_witness.output_ros[1].amount += AmountValue(1);
+            bad_witness.output_ros[1].amount += Amount(1);
             let pub_input = FreezePublicInput::from_witness(&bad_witness).unwrap();
             check_freezing_circuit(&bad_witness, &pub_input, false)?;
         }

--- a/src/circuit/freeze.rs
+++ b/src/circuit/freeze.rs
@@ -284,7 +284,7 @@ mod tests {
         let pub_input = FreezePublicInput {
             merkle_root: NodeValue::from_scalar(BaseField::from(20u8)),
             native_asset_code: AssetCode::native(),
-            fee: Amount(30u128),
+            fee: Amount::from(30u128),
             input_nullifiers,
             output_commitments,
         };
@@ -322,9 +322,9 @@ mod tests {
         let tree_depth = 2;
         let fee_keypair = UserKeyPair::generate(rng);
         let freezing_keypair = FreezerKeyPair::generate(rng);
-        let input_amounts = vec![Amount(20), Amount(30)];
-        let fee_input_amount = Amount(10);
-        let fee = Amount(5);
+        let input_amounts = vec![Amount::from(20u64), Amount::from(30u64)];
+        let fee_input_amount = Amount::from(10u64);
+        let fee = Amount::from(5u64);
         let builder = FreezeParamsBuilder::new(
             tree_depth,
             &input_amounts,
@@ -339,7 +339,7 @@ mod tests {
         // wrong fee balance
         {
             let mut bad_pub_input = pub_input.clone();
-            bad_pub_input.fee = Amount(3);
+            bad_pub_input.fee = Amount::from(3u64);
             check_freezing_circuit(&witness, &bad_pub_input, false)?;
         }
 
@@ -360,7 +360,7 @@ mod tests {
         // inconsistent amount
         {
             let mut bad_witness = witness.clone();
-            bad_witness.output_ros[1].amount += Amount(1);
+            bad_witness.output_ros[1].amount += Amount::from(1u64);
             let pub_input = FreezePublicInput::from_witness(&bad_witness).unwrap();
             check_freezing_circuit(&bad_witness, &pub_input, false)?;
         }

--- a/src/circuit/mint.rs
+++ b/src/circuit/mint.rs
@@ -215,10 +215,11 @@ impl MintPubInputVar {
         let root = circuit.create_public_variable(pub_input.merkle_root.to_scalar())?;
         let native_asset_code = circuit.create_public_variable(pub_input.native_asset_code.0)?;
         let input_nullifier = circuit.create_public_variable(pub_input.input_nullifier.0)?;
-        let fee = circuit.create_public_variable(BaseField::from(pub_input.fee))?;
+        let fee = circuit.create_public_variable(BaseField::from(pub_input.fee.0))?;
         let mint_rc = circuit.create_public_variable(pub_input.mint_rc.0)?;
         let chg_rc = circuit.create_public_variable(pub_input.chg_rc.0)?;
-        let mint_amount = circuit.create_public_variable(BaseField::from(pub_input.mint_amount))?;
+        let mint_amount =
+            circuit.create_public_variable(BaseField::from(pub_input.mint_amount.0))?;
         let mint_ac = circuit.create_public_variable(pub_input.mint_ac.0)?;
         let mint_internal_ac = circuit.create_public_variable(pub_input.mint_internal_ac.0)?;
         let mint_policy = AssetPolicyVar::new(circuit, &pub_input.mint_policy)?;
@@ -248,8 +249,9 @@ mod tests {
         errors::TxnApiError,
         keys::{AuditorKeyPair, UserKeyPair},
         structs::{
-            AssetCode, AssetCodeDigest, AssetCodeSeed, AssetPolicy, AuditMemo, CommitmentValue,
-            FreezeFlag, InternalAssetCode, Nullifier, RecordCommitment, RecordOpening,
+            AmountValue, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetPolicy, AuditMemo,
+            CommitmentValue, FreezeFlag, InternalAssetCode, Nullifier, RecordCommitment,
+            RecordOpening,
         },
         utils::params_builder::MintParamsBuilder,
         BaseField, ScalarField,
@@ -269,10 +271,10 @@ mod tests {
             merkle_root: NodeValue::from_scalar(BaseField::from(10u8)),
             native_asset_code: AssetCode::native(),
             input_nullifier: Nullifier(BaseField::from(5u8)),
-            fee: 8u64,
+            fee: AmountValue(8u128),
             mint_rc: RecordCommitment::from(&mint_ro),
             chg_rc: RecordCommitment::from(&RecordOpening::rand_for_test(rng)),
-            mint_amount: 30u64,
+            mint_amount: AmountValue(30u128),
             mint_ac,
             mint_internal_ac,
             mint_policy: AssetPolicy::rand_for_test(rng),
@@ -297,9 +299,9 @@ mod tests {
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
         let tree_depth = 2;
-        let input_amount = 30;
-        let fee = 20;
-        let mint_amount = 10;
+        let input_amount = AmountValue(30);
+        let fee = AmountValue(20);
+        let mint_amount = AmountValue(10);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -364,7 +366,7 @@ mod tests {
         // bad path: mint amount out of range
         {
             let mut bad_witness = witness.clone();
-            bad_witness.fee_ro.amount = u64::max_value();
+            bad_witness.fee_ro.amount = AmountValue(u128::max_value());
             let pub_input = MintPublicInput::from_witness(&witness)?;
             check_mint_circuit(&bad_witness, &pub_input, false)?;
         }
@@ -381,7 +383,7 @@ mod tests {
         // bad path: fee + change != input amount
         {
             let mut bad_pub_input = pub_input.clone();
-            bad_pub_input.fee += 1;
+            bad_pub_input.fee += AmountValue(1);
             check_mint_circuit(&witness, &bad_pub_input, false)?;
         }
 
@@ -406,7 +408,7 @@ mod tests {
         // bad path: inconsistent public mint amount/asset_code/policy
         {
             let mut bad_pub_input = pub_input.clone();
-            bad_pub_input.mint_amount = mint_amount + 1;
+            bad_pub_input.mint_amount = mint_amount + AmountValue(1);
             check_mint_circuit(&witness, &bad_pub_input, false)?;
 
             let mut bad_pub_input = pub_input.clone();

--- a/src/circuit/mint.rs
+++ b/src/circuit/mint.rs
@@ -249,7 +249,7 @@ mod tests {
         errors::TxnApiError,
         keys::{AuditorKeyPair, UserKeyPair},
         structs::{
-            AmountValue, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetPolicy, AuditMemo,
+            Amount, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetPolicy, AuditMemo,
             CommitmentValue, FreezeFlag, InternalAssetCode, Nullifier, RecordCommitment,
             RecordOpening,
         },
@@ -271,10 +271,10 @@ mod tests {
             merkle_root: NodeValue::from_scalar(BaseField::from(10u8)),
             native_asset_code: AssetCode::native(),
             input_nullifier: Nullifier(BaseField::from(5u8)),
-            fee: AmountValue(8u128),
+            fee: Amount(8u128),
             mint_rc: RecordCommitment::from(&mint_ro),
             chg_rc: RecordCommitment::from(&RecordOpening::rand_for_test(rng)),
-            mint_amount: AmountValue(30u128),
+            mint_amount: Amount(30u128),
             mint_ac,
             mint_internal_ac,
             mint_policy: AssetPolicy::rand_for_test(rng),
@@ -299,9 +299,9 @@ mod tests {
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
         let tree_depth = 2;
-        let input_amount = AmountValue(30);
-        let fee = AmountValue(20);
-        let mint_amount = AmountValue(10);
+        let input_amount = Amount(30);
+        let fee = Amount(20);
+        let mint_amount = Amount(10);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -366,7 +366,7 @@ mod tests {
         // bad path: mint amount out of range
         {
             let mut bad_witness = witness.clone();
-            bad_witness.fee_ro.amount = AmountValue(u128::max_value());
+            bad_witness.fee_ro.amount = Amount(u128::max_value());
             let pub_input = MintPublicInput::from_witness(&witness)?;
             check_mint_circuit(&bad_witness, &pub_input, false)?;
         }
@@ -383,7 +383,7 @@ mod tests {
         // bad path: fee + change != input amount
         {
             let mut bad_pub_input = pub_input.clone();
-            bad_pub_input.fee += AmountValue(1);
+            bad_pub_input.fee += Amount(1);
             check_mint_circuit(&witness, &bad_pub_input, false)?;
         }
 
@@ -408,7 +408,7 @@ mod tests {
         // bad path: inconsistent public mint amount/asset_code/policy
         {
             let mut bad_pub_input = pub_input.clone();
-            bad_pub_input.mint_amount = mint_amount + AmountValue(1);
+            bad_pub_input.mint_amount = mint_amount + Amount(1);
             check_mint_circuit(&witness, &bad_pub_input, false)?;
 
             let mut bad_pub_input = pub_input.clone();

--- a/src/circuit/mint.rs
+++ b/src/circuit/mint.rs
@@ -271,10 +271,10 @@ mod tests {
             merkle_root: NodeValue::from_scalar(BaseField::from(10u8)),
             native_asset_code: AssetCode::native(),
             input_nullifier: Nullifier(BaseField::from(5u8)),
-            fee: Amount(8u128),
+            fee: Amount::from(8u128),
             mint_rc: RecordCommitment::from(&mint_ro),
             chg_rc: RecordCommitment::from(&RecordOpening::rand_for_test(rng)),
-            mint_amount: Amount(30u128),
+            mint_amount: Amount::from(30u128),
             mint_ac,
             mint_internal_ac,
             mint_policy: AssetPolicy::rand_for_test(rng),
@@ -299,9 +299,9 @@ mod tests {
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
         let tree_depth = 2;
-        let input_amount = Amount(30);
-        let fee = Amount(20);
-        let mint_amount = Amount(10);
+        let input_amount = Amount::from(30u64);
+        let fee = Amount::from(20u64);
+        let mint_amount = Amount::from(10u64);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -366,7 +366,7 @@ mod tests {
         // bad path: mint amount out of range
         {
             let mut bad_witness = witness.clone();
-            bad_witness.fee_ro.amount = Amount(u128::max_value());
+            bad_witness.fee_ro.amount = Amount::from(u128::max_value());
             let pub_input = MintPublicInput::from_witness(&witness)?;
             check_mint_circuit(&bad_witness, &pub_input, false)?;
         }
@@ -383,7 +383,7 @@ mod tests {
         // bad path: fee + change != input amount
         {
             let mut bad_pub_input = pub_input.clone();
-            bad_pub_input.fee += Amount(1);
+            bad_pub_input.fee += Amount::from(1u64);
             check_mint_circuit(&witness, &bad_pub_input, false)?;
         }
 
@@ -408,7 +408,7 @@ mod tests {
         // bad path: inconsistent public mint amount/asset_code/policy
         {
             let mut bad_pub_input = pub_input.clone();
-            bad_pub_input.mint_amount = mint_amount + Amount(1);
+            bad_pub_input.mint_amount = mint_amount + Amount::from(1u64);
             check_mint_circuit(&witness, &bad_pub_input, false)?;
 
             let mut bad_pub_input = pub_input.clone();

--- a/src/circuit/structs.rs
+++ b/src/circuit/structs.rs
@@ -116,7 +116,7 @@ impl RecordOpeningVar {
         circuit: &mut PlonkCircuit<BaseField>,
         ro: &RecordOpening,
     ) -> Result<Self, PlonkError> {
-        let amount = circuit.create_variable(BaseField::from(ro.amount))?;
+        let amount = circuit.create_variable(BaseField::from(ro.amount.0))?;
         let asset_code = circuit.create_variable(ro.asset_def.code.0)?;
         let owner_addr = UserAddressVar(
             circuit
@@ -202,7 +202,8 @@ impl AssetPolicyVar {
         let cred_pk = circuit.create_signature_vk_variable(&policy.cred_pk.0)?;
         let freezer_pk =
             circuit.create_point_variable(Point::from(policy.freezer_pk.0.into_affine()))?;
-        let reveal_threshold = circuit.create_variable(BaseField::from(policy.reveal_threshold))?;
+        let reveal_threshold =
+            circuit.create_variable(BaseField::from(policy.reveal_threshold.0))?;
         Ok(Self {
             auditor_pk,
             cred_pk,

--- a/src/circuit/transfer.rs
+++ b/src/circuit/transfer.rs
@@ -387,7 +387,7 @@ mod tests {
     use crate::{
         keys::UserKeyPair,
         structs::{
-            AmountValue, AssetCode, AssetCodeSeed, AssetDefinition, AssetPolicy, AuditMemo,
+            Amount, AssetCode, AssetCodeSeed, AssetDefinition, AssetPolicy, AuditMemo,
             ExpirableCredential, FreezeFlag, Nullifier, RecordCommitment, RecordOpening,
         },
         utils::params_builder::TransferParamsBuilder,
@@ -413,7 +413,7 @@ mod tests {
             merkle_root: NodeValue::from_scalar(BaseField::from(10u8)),
             native_asset_code: AssetCode::native(),
             valid_until: 123u64,
-            fee: AmountValue(8u128),
+            fee: Amount(8u128),
             input_nullifiers: vec![Nullifier(BaseField::from(2u8)); 5],
             output_commitments: vec![RecordCommitment::from(&output_ros[0]); 4],
             audit_memo: AuditMemo::new_for_transfer_note(
@@ -445,9 +445,9 @@ mod tests {
 
         // transfer amount doesn't exceed the limit, the policy won't be applied
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs.clone())
-            .set_reveal_threshold(AmountValue(30))
-            .set_input_amounts(AmountValue(30), &[AmountValue(20), AmountValue(10)])
-            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
+            .set_reveal_threshold(Amount(30))
+            .set_input_amounts(Amount(30), &[Amount(20), Amount(10)])
+            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -462,9 +462,9 @@ mod tests {
 
         // transfer amount exceeds the limit, the policy will be applied
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs.clone())
-            .set_reveal_threshold(AmountValue(20))
-            .set_input_amounts(AmountValue(30), &[AmountValue(20), AmountValue(10)])
-            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
+            .set_reveal_threshold(Amount(20))
+            .set_input_amounts(Amount(30), &[Amount(20), Amount(10)])
+            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -492,9 +492,9 @@ mod tests {
 
         // no threshold policy, tracing policy is always applied
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_reveal_threshold(AmountValue(0))
-            .set_input_amounts(AmountValue(1), &[AmountValue(2), AmountValue(1)])
-            .set_output_amounts(AmountValue(1), &[AmountValue(1), AmountValue(2)])
+            .set_reveal_threshold(Amount(0))
+            .set_input_amounts(Amount(1), &[Amount(2), Amount(1)])
+            .set_output_amounts(Amount(1), &[Amount(1), Amount(2)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -529,8 +529,8 @@ mod tests {
         let user_keypair = UserKeyPair::generate(rng);
         let user_keypairs = vec![&user_keypair; 3];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(AmountValue(30), &[AmountValue(20), AmountValue(10)])
-            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
+            .set_input_amounts(Amount(30), &[Amount(20), Amount(10)])
+            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -571,10 +571,10 @@ mod tests {
         let builder = builder.update_input_asset_def(0, transfer_asset_def);
 
         // bad path: wrong balance
-        let builder = builder.update_input_amount(0, AmountValue(100));
+        let builder = builder.update_input_amount(0, Amount(100));
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, false)?;
-        let builder = builder.update_input_amount(0, AmountValue(20));
+        let builder = builder.update_input_amount(0, Amount(20));
 
         // bad path: wrong output commitment
         let (witness, mut pub_input) = create_witness_and_pub_input(&builder);
@@ -593,7 +593,7 @@ mod tests {
 
         // bad path: wrong txn fee
         let (witness, mut pub_input) = create_witness_and_pub_input(&builder);
-        pub_input.fee = AmountValue(21u128);
+        pub_input.fee = Amount(21u128);
         check_transfer_circuit(&witness, &pub_input, false)?;
 
         // bad path: expired credential
@@ -634,8 +634,8 @@ mod tests {
         let user_keypair = UserKeyPair::generate(rng);
         let user_keypairs = vec![&user_keypair, &user_keypair, &user_keypair];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(AmountValue(30), &[AmountValue(30), AmountValue(0)])
-            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
+            .set_input_amounts(Amount(30), &[Amount(30), Amount(0)])
+            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -650,19 +650,19 @@ mod tests {
         // test 1: dummy record with non-zero amount should fail
         let user_keypairs = vec![&user_keypair, &user_keypair, &user_keypair];
         let mut builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(AmountValue(30), &[AmountValue(30), AmountValue(0)])
-            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
+            .set_input_amounts(Amount(30), &[Amount(30), Amount(0)])
+            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
             .set_dummy_input_record(1)
             .set_input_creds(cred_expiry);
-        builder.input_ros[2].amount = AmountValue(10); // need to update amount AFTER setting dummy input
+        builder.input_ros[2].amount = Amount(10); // need to update amount AFTER setting dummy input
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, false)?;
 
         // test 2: dummy record with 0 amount should pass
         let user_keypairs = vec![&user_keypair, &user_keypair, &user_keypair];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(AmountValue(30), &[AmountValue(30), AmountValue(0)])
-            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
+            .set_input_amounts(Amount(30), &[Amount(30), Amount(0)])
+            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
             .set_dummy_input_record(1)
             .set_input_creds(cred_expiry);
         let (mut witness, mut pub_input) = create_witness_and_pub_input(&builder);

--- a/src/circuit/transfer.rs
+++ b/src/circuit/transfer.rs
@@ -326,7 +326,7 @@ impl TransferPubInputVar {
         let root = circuit.create_public_variable(pub_input.merkle_root.to_scalar())?;
         let native_asset_code = circuit.create_public_variable(pub_input.native_asset_code.0)?;
         let valid_until = circuit.create_public_variable(BaseField::from(pub_input.valid_until))?;
-        let fee = circuit.create_public_variable(BaseField::from(pub_input.fee))?;
+        let fee = circuit.create_public_variable(BaseField::from(pub_input.fee.0))?;
         let input_nullifiers = pub_input
             .input_nullifiers
             .iter()
@@ -387,8 +387,8 @@ mod tests {
     use crate::{
         keys::UserKeyPair,
         structs::{
-            AssetCode, AssetCodeSeed, AssetDefinition, AssetPolicy, AuditMemo, ExpirableCredential,
-            FreezeFlag, Nullifier, RecordCommitment, RecordOpening,
+            AmountValue, AssetCode, AssetCodeSeed, AssetDefinition, AssetPolicy, AuditMemo,
+            ExpirableCredential, FreezeFlag, Nullifier, RecordCommitment, RecordOpening,
         },
         utils::params_builder::TransferParamsBuilder,
         BaseField, ScalarField,
@@ -413,7 +413,7 @@ mod tests {
             merkle_root: NodeValue::from_scalar(BaseField::from(10u8)),
             native_asset_code: AssetCode::native(),
             valid_until: 123u64,
-            fee: 8u64,
+            fee: AmountValue(8u128),
             input_nullifiers: vec![Nullifier(BaseField::from(2u8)); 5],
             output_commitments: vec![RecordCommitment::from(&output_ros[0]); 4],
             audit_memo: AuditMemo::new_for_transfer_note(
@@ -445,9 +445,9 @@ mod tests {
 
         // transfer amount doesn't exceed the limit, the policy won't be applied
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs.clone())
-            .set_reveal_threshold(30)
-            .set_input_amounts(30, &[20, 10])
-            .set_output_amounts(19, &[17, 13])
+            .set_reveal_threshold(AmountValue(30))
+            .set_input_amounts(AmountValue(30), &[AmountValue(20), AmountValue(10)])
+            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -462,9 +462,9 @@ mod tests {
 
         // transfer amount exceeds the limit, the policy will be applied
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs.clone())
-            .set_reveal_threshold(20)
-            .set_input_amounts(30, &[20, 10])
-            .set_output_amounts(19, &[17, 13])
+            .set_reveal_threshold(AmountValue(20))
+            .set_input_amounts(AmountValue(30), &[AmountValue(20), AmountValue(10)])
+            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -492,9 +492,9 @@ mod tests {
 
         // no threshold policy, tracing policy is always applied
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_reveal_threshold(0)
-            .set_input_amounts(1, &[2, 1])
-            .set_output_amounts(1, &[1, 2])
+            .set_reveal_threshold(AmountValue(0))
+            .set_input_amounts(AmountValue(1), &[AmountValue(2), AmountValue(1)])
+            .set_output_amounts(AmountValue(1), &[AmountValue(1), AmountValue(2)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -529,8 +529,8 @@ mod tests {
         let user_keypair = UserKeyPair::generate(rng);
         let user_keypairs = vec![&user_keypair; 3];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(30, &[20, 10])
-            .set_output_amounts(19, &[17, 13])
+            .set_input_amounts(AmountValue(30), &[AmountValue(20), AmountValue(10)])
+            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -571,10 +571,10 @@ mod tests {
         let builder = builder.update_input_asset_def(0, transfer_asset_def);
 
         // bad path: wrong balance
-        let builder = builder.update_input_amount(0, 100);
+        let builder = builder.update_input_amount(0, AmountValue(100));
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, false)?;
-        let builder = builder.update_input_amount(0, 20);
+        let builder = builder.update_input_amount(0, AmountValue(20));
 
         // bad path: wrong output commitment
         let (witness, mut pub_input) = create_witness_and_pub_input(&builder);
@@ -593,7 +593,7 @@ mod tests {
 
         // bad path: wrong txn fee
         let (witness, mut pub_input) = create_witness_and_pub_input(&builder);
-        pub_input.fee = 21u64;
+        pub_input.fee = AmountValue(21u128);
         check_transfer_circuit(&witness, &pub_input, false)?;
 
         // bad path: expired credential
@@ -634,8 +634,8 @@ mod tests {
         let user_keypair = UserKeyPair::generate(rng);
         let user_keypairs = vec![&user_keypair, &user_keypair, &user_keypair];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(30, &[30, 0])
-            .set_output_amounts(19, &[17, 13])
+            .set_input_amounts(AmountValue(30), &[AmountValue(30), AmountValue(0)])
+            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -650,19 +650,19 @@ mod tests {
         // test 1: dummy record with non-zero amount should fail
         let user_keypairs = vec![&user_keypair, &user_keypair, &user_keypair];
         let mut builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(30, &[30, 0])
-            .set_output_amounts(19, &[17, 13])
+            .set_input_amounts(AmountValue(30), &[AmountValue(30), AmountValue(0)])
+            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
             .set_dummy_input_record(1)
             .set_input_creds(cred_expiry);
-        builder.input_ros[2].amount = 10; // need to update amount AFTER setting dummy input
+        builder.input_ros[2].amount = AmountValue(10); // need to update amount AFTER setting dummy input
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, false)?;
 
         // test 2: dummy record with 0 amount should pass
         let user_keypairs = vec![&user_keypair, &user_keypair, &user_keypair];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(30, &[30, 0])
-            .set_output_amounts(19, &[17, 13])
+            .set_input_amounts(AmountValue(30), &[AmountValue(30), AmountValue(0)])
+            .set_output_amounts(AmountValue(19), &[AmountValue(17), AmountValue(13)])
             .set_dummy_input_record(1)
             .set_input_creds(cred_expiry);
         let (mut witness, mut pub_input) = create_witness_and_pub_input(&builder);

--- a/src/circuit/transfer.rs
+++ b/src/circuit/transfer.rs
@@ -545,6 +545,17 @@ mod tests {
         let rng = &mut ark_std::test_rng();
         let cred_expiry = 9998u64;
         let user_keypair = UserKeyPair::generate(rng);
+        let user_keypairs = vec![&user_keypair; 2];
+        // bad path: output amount out of range
+        let builder = TransferParamsBuilder::new_non_native(2, 2, Some(2), user_keypairs)
+            .set_input_amounts(Amount::from(30u64), &[Amount::from(u128::MAX - 100)])
+            .set_output_amounts(Amount::from(19u64), &[Amount::from(u128::MAX - 100)])
+            .set_input_creds(cred_expiry);
+        let (witness, pub_input) = create_witness_and_pub_input(&builder);
+        check_transfer_circuit(&witness, &pub_input, false)?;
+
+        // good path
+        let user_keypair = UserKeyPair::generate(rng);
         let user_keypairs = vec![&user_keypair; 3];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
             .set_input_amounts(

--- a/src/circuit/transfer.rs
+++ b/src/circuit/transfer.rs
@@ -413,7 +413,7 @@ mod tests {
             merkle_root: NodeValue::from_scalar(BaseField::from(10u8)),
             native_asset_code: AssetCode::native(),
             valid_until: 123u64,
-            fee: Amount(8u128),
+            fee: Amount::from(8u64),
             input_nullifiers: vec![Nullifier(BaseField::from(2u8)); 5],
             output_commitments: vec![RecordCommitment::from(&output_ros[0]); 4],
             audit_memo: AuditMemo::new_for_transfer_note(
@@ -445,9 +445,15 @@ mod tests {
 
         // transfer amount doesn't exceed the limit, the policy won't be applied
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs.clone())
-            .set_reveal_threshold(Amount(30))
-            .set_input_amounts(Amount(30), &[Amount(20), Amount(10)])
-            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
+            .set_reveal_threshold(Amount::from(30u64))
+            .set_input_amounts(
+                Amount::from(30u64),
+                &[Amount::from(20u64), Amount::from(10u64)],
+            )
+            .set_output_amounts(
+                Amount::from(19u64),
+                &[Amount::from(17u64), Amount::from(13u64)],
+            )
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -462,9 +468,15 @@ mod tests {
 
         // transfer amount exceeds the limit, the policy will be applied
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs.clone())
-            .set_reveal_threshold(Amount(20))
-            .set_input_amounts(Amount(30), &[Amount(20), Amount(10)])
-            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
+            .set_reveal_threshold(Amount::from(20u64))
+            .set_input_amounts(
+                Amount::from(30u64),
+                &[Amount::from(20u64), Amount::from(10u64)],
+            )
+            .set_output_amounts(
+                Amount::from(19u64),
+                &[Amount::from(17u64), Amount::from(13u64)],
+            )
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -492,9 +504,15 @@ mod tests {
 
         // no threshold policy, tracing policy is always applied
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_reveal_threshold(Amount(0))
-            .set_input_amounts(Amount(1), &[Amount(2), Amount(1)])
-            .set_output_amounts(Amount(1), &[Amount(1), Amount(2)])
+            .set_reveal_threshold(Amount::from(0u64))
+            .set_input_amounts(
+                Amount::from(1u64),
+                &[Amount::from(2u64), Amount::from(1u64)],
+            )
+            .set_output_amounts(
+                Amount::from(1u64),
+                &[Amount::from(1u64), Amount::from(2u64)],
+            )
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -529,8 +547,14 @@ mod tests {
         let user_keypair = UserKeyPair::generate(rng);
         let user_keypairs = vec![&user_keypair; 3];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(Amount(30), &[Amount(20), Amount(10)])
-            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
+            .set_input_amounts(
+                Amount::from(30u64),
+                &[Amount::from(20u64), Amount::from(10u64)],
+            )
+            .set_output_amounts(
+                Amount::from(19u64),
+                &[Amount::from(17u64), Amount::from(13u64)],
+            )
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -571,10 +595,10 @@ mod tests {
         let builder = builder.update_input_asset_def(0, transfer_asset_def);
 
         // bad path: wrong balance
-        let builder = builder.update_input_amount(0, Amount(100));
+        let builder = builder.update_input_amount(0, Amount::from(100u64));
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, false)?;
-        let builder = builder.update_input_amount(0, Amount(20));
+        let builder = builder.update_input_amount(0, Amount::from(20u64));
 
         // bad path: wrong output commitment
         let (witness, mut pub_input) = create_witness_and_pub_input(&builder);
@@ -593,7 +617,7 @@ mod tests {
 
         // bad path: wrong txn fee
         let (witness, mut pub_input) = create_witness_and_pub_input(&builder);
-        pub_input.fee = Amount(21u128);
+        pub_input.fee = Amount::from(21u128);
         check_transfer_circuit(&witness, &pub_input, false)?;
 
         // bad path: expired credential
@@ -634,8 +658,14 @@ mod tests {
         let user_keypair = UserKeyPair::generate(rng);
         let user_keypairs = vec![&user_keypair, &user_keypair, &user_keypair];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(Amount(30), &[Amount(30), Amount(0)])
-            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
+            .set_input_amounts(
+                Amount::from(30u64),
+                &[Amount::from(30u64), Amount::from(0u64)],
+            )
+            .set_output_amounts(
+                Amount::from(19u64),
+                &[Amount::from(17u64), Amount::from(13u64)],
+            )
             .set_input_creds(cred_expiry);
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, true)?;
@@ -650,19 +680,31 @@ mod tests {
         // test 1: dummy record with non-zero amount should fail
         let user_keypairs = vec![&user_keypair, &user_keypair, &user_keypair];
         let mut builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(Amount(30), &[Amount(30), Amount(0)])
-            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
+            .set_input_amounts(
+                Amount::from(30u64),
+                &[Amount::from(30u64), Amount::from(0u64)],
+            )
+            .set_output_amounts(
+                Amount::from(19u64),
+                &[Amount::from(17u64), Amount::from(13u64)],
+            )
             .set_dummy_input_record(1)
             .set_input_creds(cred_expiry);
-        builder.input_ros[2].amount = Amount(10); // need to update amount AFTER setting dummy input
+        builder.input_ros[2].amount = Amount::from(10u64); // need to update amount AFTER setting dummy input
         let (witness, pub_input) = create_witness_and_pub_input(&builder);
         check_transfer_circuit(&witness, &pub_input, false)?;
 
         // test 2: dummy record with 0 amount should pass
         let user_keypairs = vec![&user_keypair, &user_keypair, &user_keypair];
         let builder = TransferParamsBuilder::new_non_native(3, 3, Some(2), user_keypairs)
-            .set_input_amounts(Amount(30), &[Amount(30), Amount(0)])
-            .set_output_amounts(Amount(19), &[Amount(17), Amount(13)])
+            .set_input_amounts(
+                Amount::from(30u64),
+                &[Amount::from(30u64), Amount::from(0u64)],
+            )
+            .set_output_amounts(
+                Amount::from(19u64),
+                &[Amount::from(17u64), Amount::from(13u64)],
+            )
             .set_dummy_input_record(1)
             .set_input_creds(cred_expiry);
         let (mut witness, mut pub_input) = create_witness_and_pub_input(&builder);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -48,7 +48,7 @@ pub const ATTRS_LEN: usize = 8;
 pub const MAX_TIMESTAMP_LEN: usize = 20;
 
 /// Amount value size (in bits)
-pub(crate) const AMOUNT_LEN: usize = 63;
+pub(crate) const AMOUNT_LEN: usize = 127;
 
 // 31 bytes a chunk
 pub(crate) const BLS_SCALAR_BYTE_CAPACITY: usize = BLS_SCALAR_BIT_CAPACITY as usize / 8;

--- a/src/freeze.rs
+++ b/src/freeze.rs
@@ -17,7 +17,7 @@ use crate::{
         self, FreezeProvingKey, FreezePublicInput, FreezeValidityProof, FreezeVerifyingKey,
         FreezeWitness,
     },
-    structs::{AssetCode, Nullifier, RecordCommitment, RecordOpening, TxnFeeInfo},
+    structs::{AmountValue, AssetCode, Nullifier, RecordCommitment, RecordOpening, TxnFeeInfo},
     utils::txn_helpers::{freeze::*, *},
     AccMemberWitness, KeyPair, NodeValue, VerKey,
 };
@@ -68,7 +68,7 @@ pub struct FreezeAuxInfo {
     /// Accumulator state
     pub merkle_root: NodeValue,
     /// proposed fee in native asset type for the transfer
-    pub fee: u64,
+    pub fee: AmountValue,
     /// Transaction memos signature verification key (usually used for signing
     /// receiver memos)
     pub txn_memo_ver_key: VerKey,
@@ -206,7 +206,7 @@ mod test {
             universal_setup_for_staging,
         },
         sign_receiver_memos,
-        structs::{AssetDefinition, AssetPolicy, FreezeFlag, ReceiverMemo},
+        structs::{AmountValue, AssetDefinition, AssetPolicy, FreezeFlag, ReceiverMemo},
         utils::params_builder::FreezeParamsBuilder,
         TransactionNote,
     };
@@ -223,15 +223,15 @@ mod test {
         let (proving_key, verifying_key, _) =
             freeze::preprocess(&universal_param, num_input, tree_depth)?;
 
-        let input_amounts = vec![20, 30];
-        let fee_input_amount = 10;
+        let input_amounts = vec![AmountValue(20), AmountValue(30)];
+        let fee_input_amount = AmountValue(10);
         let fee_keypair = UserKeyPair::generate(rng);
         let freeze_keypair = FreezerKeyPair::generate(rng);
 
         // ====================================
         // zero fee
         // ====================================
-        let fee = 0;
+        let fee = AmountValue(0);
 
         let builder = FreezeParamsBuilder::new(
             tree_depth,
@@ -247,7 +247,7 @@ mod test {
         // ====================================
         // non-zero fee
         // ====================================
-        let fee = 5;
+        let fee = AmountValue(5);
 
         let builder = FreezeParamsBuilder::new(
             tree_depth,
@@ -300,7 +300,9 @@ mod test {
 
         // fee input amount < change amount
         {
-            let bad_builder = builder.clone().update_fee_input_amount(builder.fee - 1);
+            let bad_builder = builder
+                .clone()
+                .update_fee_input_amount(builder.fee - AmountValue(1));
             assert!(bad_builder.build_freeze_note(rng, &proving_key).is_err());
         }
 

--- a/src/freeze.rs
+++ b/src/freeze.rs
@@ -223,15 +223,15 @@ mod test {
         let (proving_key, verifying_key, _) =
             freeze::preprocess(&universal_param, num_input, tree_depth)?;
 
-        let input_amounts = vec![Amount(20), Amount(30)];
-        let fee_input_amount = Amount(10);
+        let input_amounts = vec![Amount::from(20u64), Amount::from(30u64)];
+        let fee_input_amount = Amount::from(10u64);
         let fee_keypair = UserKeyPair::generate(rng);
         let freeze_keypair = FreezerKeyPair::generate(rng);
 
         // ====================================
         // zero fee
         // ====================================
-        let fee = Amount(0);
+        let fee = Amount::from(0u64);
 
         let builder = FreezeParamsBuilder::new(
             tree_depth,
@@ -247,7 +247,7 @@ mod test {
         // ====================================
         // non-zero fee
         // ====================================
-        let fee = Amount(5);
+        let fee = Amount::from(5u64);
 
         let builder = FreezeParamsBuilder::new(
             tree_depth,
@@ -302,7 +302,7 @@ mod test {
         {
             let bad_builder = builder
                 .clone()
-                .update_fee_input_amount(builder.fee - Amount(1));
+                .update_fee_input_amount(builder.fee - Amount::from(1u64));
             assert!(bad_builder.build_freeze_note(rng, &proving_key).is_err());
         }
 

--- a/src/freeze.rs
+++ b/src/freeze.rs
@@ -17,7 +17,7 @@ use crate::{
         self, FreezeProvingKey, FreezePublicInput, FreezeValidityProof, FreezeVerifyingKey,
         FreezeWitness,
     },
-    structs::{AmountValue, AssetCode, Nullifier, RecordCommitment, RecordOpening, TxnFeeInfo},
+    structs::{Amount, AssetCode, Nullifier, RecordCommitment, RecordOpening, TxnFeeInfo},
     utils::txn_helpers::{freeze::*, *},
     AccMemberWitness, KeyPair, NodeValue, VerKey,
 };
@@ -68,7 +68,7 @@ pub struct FreezeAuxInfo {
     /// Accumulator state
     pub merkle_root: NodeValue,
     /// proposed fee in native asset type for the transfer
-    pub fee: AmountValue,
+    pub fee: Amount,
     /// Transaction memos signature verification key (usually used for signing
     /// receiver memos)
     pub txn_memo_ver_key: VerKey,
@@ -206,7 +206,7 @@ mod test {
             universal_setup_for_staging,
         },
         sign_receiver_memos,
-        structs::{AmountValue, AssetDefinition, AssetPolicy, FreezeFlag, ReceiverMemo},
+        structs::{Amount, AssetDefinition, AssetPolicy, FreezeFlag, ReceiverMemo},
         utils::params_builder::FreezeParamsBuilder,
         TransactionNote,
     };
@@ -223,15 +223,15 @@ mod test {
         let (proving_key, verifying_key, _) =
             freeze::preprocess(&universal_param, num_input, tree_depth)?;
 
-        let input_amounts = vec![AmountValue(20), AmountValue(30)];
-        let fee_input_amount = AmountValue(10);
+        let input_amounts = vec![Amount(20), Amount(30)];
+        let fee_input_amount = Amount(10);
         let fee_keypair = UserKeyPair::generate(rng);
         let freeze_keypair = FreezerKeyPair::generate(rng);
 
         // ====================================
         // zero fee
         // ====================================
-        let fee = AmountValue(0);
+        let fee = Amount(0);
 
         let builder = FreezeParamsBuilder::new(
             tree_depth,
@@ -247,7 +247,7 @@ mod test {
         // ====================================
         // non-zero fee
         // ====================================
-        let fee = AmountValue(5);
+        let fee = Amount(5);
 
         let builder = FreezeParamsBuilder::new(
             tree_depth,
@@ -302,7 +302,7 @@ mod test {
         {
             let bad_builder = builder
                 .clone()
-                .update_fee_input_amount(builder.fee - AmountValue(1));
+                .update_fee_input_amount(builder.fee - Amount(1));
             assert!(bad_builder.build_freeze_note(rng, &proving_key).is_err());
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -646,7 +646,7 @@ mod test {
         // The original fee amount 5 changes after changing the `rand()` functions in
         // `ParamBuilder`. Is there an API that returns the correct fee amount
         // automatically? TODO: replace this hardwired value
-        assert_eq!(fee, Amount(69_u128));
+        assert_eq!(fee, Amount::from(45_u128));
 
         // Overflow
         let txn = params.txns[0].clone();
@@ -656,7 +656,7 @@ mod test {
         };
 
         let mut v = v.unwrap();
-        v.aux_info.fee = Amount(u128::MAX);
+        v.aux_info.fee = Amount::from(u128::MAX);
         let mut txns = params.txns.clone();
         txns.push(TransactionNote::Transfer(v));
 
@@ -725,6 +725,8 @@ mod test {
             &verifying_keys
         )
         .is_err());
+        // TODO: this check will fail when all of the transactions are native, which
+        // happened with certain probability
         roots[0] = old_root_0;
         assert!(txn_batch_verify(
             &params.txns,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //! Each transaction could decide to include a non-negative fee in _native asset
 //! type_.
 //! This is achieved by providing a [`structs::FeeInput`] and specify the
-//! actual amount of `fee: u64` to pay whenever you generate a note.
+//! actual amount of `fee: AmountValue` to pay whenever you generate a note.
 //! Be careful: the value of `FeeInput` has to be no smaller than `fee`, and the
 //! difference is _fee change_ which would be included in the output with the
 //! same owner as the fee payer.
@@ -146,6 +146,9 @@
 #[cfg(test)]
 extern crate std;
 
+#[macro_use]
+extern crate derive_more;
+
 pub mod bench_utils;
 pub(crate) mod circuit;
 pub mod constants;
@@ -170,8 +173,8 @@ use crate::{
     keys::UserPubKey,
     proof::transfer::TransferVerifyingKey,
     structs::{
-        AssetDefinition, BlindFactor, FreezeFlag, Nullifier, ReceiverMemo, RecordCommitment,
-        RecordOpening,
+        AmountValue, AssetDefinition, BlindFactor, FreezeFlag, Nullifier, ReceiverMemo,
+        RecordCommitment, RecordOpening,
     },
     utils::txn_helpers::get_receiver_memos_digest,
 };
@@ -524,7 +527,7 @@ pub fn txn_batch_verify(
 /// * `blind` - blinding factor of the record commitment
 pub fn derive_txns_fee_records(
     fee_collectors: &[UserPubKey],
-    fees: &[u64],
+    fees: &[AmountValue],
     blinds: &[BlindFactor],
 ) -> Result<Vec<RecordCommitment>, TxnApiError> {
     if fees.is_empty() {
@@ -557,8 +560,8 @@ pub fn derive_txns_fee_records(
 }
 
 /// Compute amount of claimable transaction fee
-pub fn calculate_fee(txns: &[TransactionNote]) -> Result<u64, TxnApiError> {
-    let fee_amounts: Vec<u64> = txns
+pub fn calculate_fee(txns: &[TransactionNote]) -> Result<AmountValue, TxnApiError> {
+    let fee_amounts: Vec<AmountValue> = txns
         .iter()
         .map(|txn| match txn {
             TransactionNote::Transfer(note) => note.aux_info.fee,
@@ -566,7 +569,7 @@ pub fn calculate_fee(txns: &[TransactionNote]) -> Result<u64, TxnApiError> {
             TransactionNote::Freeze(note) => note.aux_info.fee,
         })
         .collect();
-    utils::safe_sum_u64(&fee_amounts)
+    utils::safe_sum_amount_value(&fee_amounts)
         .ok_or_else(|| TxnApiError::IncorrectFee("Overflow in total fee".to_string()))
 }
 
@@ -582,9 +585,13 @@ pub fn sign_receiver_memos(
 #[cfg(test)]
 mod test {
     use crate::{
-        calculate_fee, derive_txns_fee_records, errors::TxnApiError, keys::UserPubKey,
-        structs::BlindFactor, txn_batch_verify, utils::params_builder::TxnsParams, KeyPair,
-        TransactionNote,
+        calculate_fee, derive_txns_fee_records,
+        errors::TxnApiError,
+        keys::UserPubKey,
+        structs::{AmountValue, BlindFactor},
+        txn_batch_verify,
+        utils::params_builder::TxnsParams,
+        KeyPair, TransactionNote,
     };
     use ark_std::{vec, vec::Vec};
 
@@ -636,7 +643,10 @@ mod test {
         // Test calculate fee
         // todo: check this fee is correct
         let fee = calculate_fee(&params.txns).unwrap();
-        assert_eq!(fee, 5_u64);
+        // The original fee amount 5 changes after changing the `rand()` functions in
+        // `ParamBuilder`. Is there an API that returns the correct fee amount
+        // automatically? TODO: replace this hardwired value
+        assert_eq!(fee, AmountValue(69_u128));
 
         // Overflow
         let txn = params.txns[0].clone();
@@ -646,7 +656,7 @@ mod test {
         };
 
         let mut v = v.unwrap();
-        v.aux_info.fee = u64::MAX;
+        v.aux_info.fee = AmountValue(u128::MAX);
         let mut txns = params.txns.clone();
         txns.push(TransactionNote::Transfer(v));
 
@@ -660,7 +670,7 @@ mod test {
         let blinds = (0..7)
             .map(|_| BlindFactor::rand(rng))
             .collect::<Vec<BlindFactor>>();
-        let fee_amounts: Vec<u64> = txns
+        let fee_amounts: Vec<AmountValue> = txns
             .iter()
             .map(|txn| match txn {
                 TransactionNote::Transfer(note) => note.aux_info.fee,
@@ -668,7 +678,7 @@ mod test {
                 TransactionNote::Freeze(note) => note.aux_info.fee,
             })
             .collect();
-        assert!(derive_txns_fee_records(&pks, &fee_amounts, &blinds).is_ok());
+        assert!(derive_txns_fee_records(&pks, &fee_amounts[..], &blinds).is_ok());
         assert!(
             derive_txns_fee_records(&[UserPubKey::default()], &[], &[BlindFactor::rand(rng)])
                 .is_err()

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -230,8 +230,8 @@ mod test {
         let (proving_key, verifying_key, _) =
             proof::mint::preprocess(&universal_param, tree_depth)?;
 
-        let input_amount = Amount(10);
-        let mint_amount = Amount(35);
+        let input_amount = Amount::from(10u64);
+        let mint_amount = Amount::from(35u64);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
@@ -239,7 +239,7 @@ mod test {
         // ====================================
         // zero fee
         // ====================================
-        let fee = Amount(0);
+        let fee = Amount::from(0u64);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -267,7 +267,7 @@ mod test {
         // ====================================
         // non-zero fee
         // ====================================
-        let fee = Amount(4);
+        let fee = Amount::from(4u64);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -340,7 +340,7 @@ mod test {
         // wrong fee > input amount
         {
             let mut bad_builder = builder.clone();
-            bad_builder.fee = bad_builder.fee_ro.amount + Amount(1);
+            bad_builder.fee = bad_builder.fee_ro.amount + Amount::from(1u64);
             assert!(bad_builder.build_mint_note(rng, &proving_key).is_err());
         }
 

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -17,7 +17,7 @@ use crate::{
         self, MintProvingKey, MintPublicInput, MintValidityProof, MintVerifyingKey, MintWitness,
     },
     structs::{
-        AmountValue, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AuditMemo,
+        Amount, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AuditMemo,
         InternalAssetCode, Nullifier, RecordCommitment, RecordOpening, TxnFeeInfo,
     },
     utils::txn_helpers::{mint::*, *},
@@ -48,7 +48,7 @@ pub struct MintNote {
     /// output commitment for the minted asset
     pub mint_comm: RecordCommitment,
     /// the amount of the minted asset
-    pub mint_amount: AmountValue,
+    pub mint_amount: Amount,
     /// the asset definition of the asset
     pub mint_asset_def: AssetDefinition,
     /// the asset code
@@ -77,7 +77,7 @@ pub struct MintAuxInfo {
     /// Merkle tree accumulator root
     pub merkle_root: NodeValue,
     /// Proposed transaction fee in native asset type
-    pub fee: AmountValue,
+    pub fee: Amount,
     /// Transaction memos signature verification key (usually used for signing
     /// receiver memos)
     pub txn_memo_ver_key: VerKey,
@@ -214,7 +214,7 @@ mod test {
             universal_setup_for_staging,
         },
         sign_receiver_memos,
-        structs::{AmountValue, AssetCodeSeed, AssetDefinition, FreezeFlag, ReceiverMemo},
+        structs::{Amount, AssetCodeSeed, AssetDefinition, FreezeFlag, ReceiverMemo},
         utils::params_builder::{MintParamsBuilder, PolicyRevealAttr},
         KeyPair, NodeValue, TransactionNote,
     };
@@ -230,8 +230,8 @@ mod test {
         let (proving_key, verifying_key, _) =
             proof::mint::preprocess(&universal_param, tree_depth)?;
 
-        let input_amount = AmountValue(10);
-        let mint_amount = AmountValue(35);
+        let input_amount = Amount(10);
+        let mint_amount = Amount(35);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
@@ -239,7 +239,7 @@ mod test {
         // ====================================
         // zero fee
         // ====================================
-        let fee = AmountValue(0);
+        let fee = Amount(0);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -267,7 +267,7 @@ mod test {
         // ====================================
         // non-zero fee
         // ====================================
-        let fee = AmountValue(4);
+        let fee = Amount(4);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -340,7 +340,7 @@ mod test {
         // wrong fee > input amount
         {
             let mut bad_builder = builder.clone();
-            bad_builder.fee = bad_builder.fee_ro.amount + AmountValue(1);
+            bad_builder.fee = bad_builder.fee_ro.amount + Amount(1);
             assert!(bad_builder.build_mint_note(rng, &proving_key).is_err());
         }
 
@@ -356,7 +356,7 @@ mod test {
 
     fn test_mint_note_helper(
         builder: &MintParamsBuilder,
-        mint_amount: AmountValue,
+        mint_amount: Amount,
         proving_key: &MintProvingKey,
         verifying_key: &MintVerifyingKey,
         receiver_keypair: &UserKeyPair,

--- a/src/proof/freeze.rs
+++ b/src/proof/freeze.rs
@@ -20,7 +20,7 @@ use crate::{
     freeze::FreezeNoteInput,
     keys::{FreezerKeyPair, FreezerPubKey, UserKeyPair},
     proof::UniversalParam,
-    structs::{AmountValue, AssetCode, Nullifier, RecordCommitment, RecordOpening, TxnFeeInfo},
+    structs::{Amount, AssetCode, Nullifier, RecordCommitment, RecordOpening, TxnFeeInfo},
     AccMemberWitness, BaseField, MerkleTree, NodeValue, PairingEngine, VerKey,
 };
 use ark_serialize::*;
@@ -247,7 +247,7 @@ impl<'a> FreezeWitness<'a> {
 pub(crate) struct FreezePublicInput {
     pub(crate) merkle_root: NodeValue,
     pub(crate) native_asset_code: AssetCode,
-    pub(crate) fee: AmountValue,
+    pub(crate) fee: Amount,
     pub(crate) input_nullifiers: Vec<Nullifier>,
     pub(crate) output_commitments: Vec<RecordCommitment>,
 }
@@ -348,7 +348,7 @@ mod test {
         errors::TxnApiError,
         keys::{FreezerKeyPair, UserKeyPair},
         proof::{freeze, universal_setup_for_staging},
-        structs::AmountValue,
+        structs::Amount,
         utils::params_builder::FreezeParamsBuilder,
         KeyPair,
     };
@@ -360,9 +360,9 @@ mod test {
         let rng = &mut ark_std::test_rng();
         let fee_keypair = UserKeyPair::generate(rng);
         let freezing_keypair = FreezerKeyPair::generate(rng);
-        let input_amounts = vec![AmountValue(20), AmountValue(30)];
-        let fee_input_amount = AmountValue(10);
-        let fee = AmountValue(5);
+        let input_amounts = vec![Amount(20), Amount(30)];
+        let fee_input_amount = Amount(10);
+        let fee = Amount(5);
         let builder = FreezeParamsBuilder::new(
             2,
             &input_amounts,
@@ -403,7 +403,7 @@ mod test {
         );
 
         // negative fee
-        let bad_fee = fee_input_amount + AmountValue(2);
+        let bad_fee = fee_input_amount + Amount(2);
         let builder = FreezeParamsBuilder::new(
             2,
             &input_amounts,
@@ -432,9 +432,9 @@ mod test {
         let (proving_key, verifying_key, _) =
             freeze::preprocess(&universal_param, num_input, tree_depth)?;
 
-        let input_amounts = vec![AmountValue(20), AmountValue(30)];
-        let fee_input_amount = AmountValue(10);
-        let fee = AmountValue(5);
+        let input_amounts = vec![Amount(20), Amount(30)];
+        let fee_input_amount = Amount(10);
+        let fee = Amount(5);
         let fee_keypair = UserKeyPair::generate(rng);
         let freeze_keypair = FreezerKeyPair::generate(rng);
         let recv_memos_ver_key = KeyPair::generate(rng).ver_key();
@@ -464,10 +464,10 @@ mod test {
         .is_ok());
 
         // another instance
-        let fee_input_amount = AmountValue(rng.next_u64() as u128);
-        let amounts_2 = AmountValue(rng.next_u32() as u128);
-        let amounts_3 = AmountValue(rng.next_u32() as u128);
-        let fee = AmountValue(rng.gen_range(1..fee_input_amount.0));
+        let fee_input_amount = Amount(rng.next_u64() as u128);
+        let amounts_2 = Amount(rng.next_u32() as u128);
+        let amounts_3 = Amount(rng.next_u32() as u128);
+        let fee = Amount(rng.gen_range(1..fee_input_amount.0));
         let fee_keypair = UserKeyPair::generate(rng);
         let freeze_keypair = FreezerKeyPair::generate(rng);
         let builder = FreezeParamsBuilder::new(

--- a/src/proof/freeze.rs
+++ b/src/proof/freeze.rs
@@ -360,9 +360,9 @@ mod test {
         let rng = &mut ark_std::test_rng();
         let fee_keypair = UserKeyPair::generate(rng);
         let freezing_keypair = FreezerKeyPair::generate(rng);
-        let input_amounts = vec![Amount(20), Amount(30)];
-        let fee_input_amount = Amount(10);
-        let fee = Amount(5);
+        let input_amounts = vec![Amount::from(20u64), Amount::from(30u64)];
+        let fee_input_amount = Amount::from(10u64);
+        let fee = Amount::from(5u64);
         let builder = FreezeParamsBuilder::new(
             2,
             &input_amounts,
@@ -403,7 +403,7 @@ mod test {
         );
 
         // negative fee
-        let bad_fee = fee_input_amount + Amount(2);
+        let bad_fee = fee_input_amount + Amount::from(2u64);
         let builder = FreezeParamsBuilder::new(
             2,
             &input_amounts,
@@ -432,9 +432,9 @@ mod test {
         let (proving_key, verifying_key, _) =
             freeze::preprocess(&universal_param, num_input, tree_depth)?;
 
-        let input_amounts = vec![Amount(20), Amount(30)];
-        let fee_input_amount = Amount(10);
-        let fee = Amount(5);
+        let input_amounts = vec![Amount::from(20u64), Amount::from(30u64)];
+        let fee_input_amount = Amount::from(10u64);
+        let fee = Amount::from(5u64);
         let fee_keypair = UserKeyPair::generate(rng);
         let freeze_keypair = FreezerKeyPair::generate(rng);
         let recv_memos_ver_key = KeyPair::generate(rng).ver_key();
@@ -464,10 +464,10 @@ mod test {
         .is_ok());
 
         // another instance
-        let fee_input_amount = Amount(rng.next_u64() as u128);
-        let amounts_2 = Amount(rng.next_u32() as u128);
-        let amounts_3 = Amount(rng.next_u32() as u128);
-        let fee = Amount(rng.gen_range(1..fee_input_amount.0));
+        let fee_input_amount = Amount::from(rng.next_u64() as u128);
+        let amounts_2 = Amount::from(rng.next_u32() as u128);
+        let amounts_3 = Amount::from(rng.next_u32() as u128);
+        let fee = Amount::from(rng.gen_range(1..fee_input_amount.0));
         let fee_keypair = UserKeyPair::generate(rng);
         let freeze_keypair = FreezerKeyPair::generate(rng);
         let builder = FreezeParamsBuilder::new(

--- a/src/proof/mint.rs
+++ b/src/proof/mint.rs
@@ -20,8 +20,8 @@ use crate::{
     errors::TxnApiError,
     keys::UserKeyPair,
     structs::{
-        AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AssetPolicy, AuditMemo,
-        InternalAssetCode, Nullifier, RecordCommitment, RecordOpening,
+        AmountValue, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AssetPolicy,
+        AuditMemo, InternalAssetCode, Nullifier, RecordCommitment, RecordOpening,
     },
     BaseField, CurveParam, PairingEngine, ScalarField,
 };
@@ -188,10 +188,10 @@ pub(crate) struct MintPublicInput {
     pub(crate) merkle_root: NodeValue<BaseField>,
     pub(crate) native_asset_code: AssetCode,
     pub(crate) input_nullifier: Nullifier,
-    pub(crate) fee: u64,
+    pub(crate) fee: AmountValue,
     pub(crate) mint_rc: RecordCommitment,
     pub(crate) chg_rc: RecordCommitment,
-    pub(crate) mint_amount: u64,
+    pub(crate) mint_amount: AmountValue,
     pub(crate) mint_ac: AssetCode,
     pub(crate) mint_internal_ac: InternalAssetCode,
     pub(crate) mint_policy: AssetPolicy,
@@ -257,10 +257,10 @@ impl MintPublicInput {
             self.merkle_root.to_scalar(),
             self.native_asset_code.0,
             self.input_nullifier.0,
-            BaseField::from(self.fee),
+            BaseField::from(self.fee.0),
             self.mint_rc.0,
             self.chg_rc.0,
-            BaseField::from(self.mint_amount),
+            BaseField::from(self.mint_amount.0),
             self.mint_ac.0,
             self.mint_internal_ac.0,
         ];
@@ -277,6 +277,7 @@ mod test {
         errors::TxnApiError,
         keys::{AuditorKeyPair, UserKeyPair},
         proof::{mint, universal_setup_for_staging},
+        structs::AmountValue,
         utils::params_builder::MintParamsBuilder,
     };
     use jf_primitives::schnorr_dsa;
@@ -286,9 +287,9 @@ mod test {
     fn test_pub_input_creation() -> Result<(), TxnApiError> {
         let rng = &mut ark_std::test_rng();
         let tree_depth = 2;
-        let input_amount = 30;
-        let fee = 10;
-        let mint_amount = 15;
+        let input_amount = AmountValue(30);
+        let fee = AmountValue(10);
+        let mint_amount = AmountValue(15);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
@@ -311,7 +312,7 @@ mod test {
         );
 
         // negative fee should fail
-        let bad_fee = input_amount + 1;
+        let bad_fee = input_amount + AmountValue(1);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -340,9 +341,9 @@ mod test {
         let universal_param = universal_setup_for_staging(max_degree, rng)?;
         let (proving_key, verifying_key, _) = mint::preprocess(&universal_param, tree_depth)?;
 
-        let input_amount = 10;
-        let fee = 4;
-        let mint_amount = 35;
+        let input_amount = AmountValue(10);
+        let fee = AmountValue(4);
+        let mint_amount = AmountValue(35);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
@@ -378,7 +379,7 @@ mod test {
 
         let wrong_public_input = {
             let mut pub_input = public_inputs_1.clone();
-            pub_input.mint_amount = mint_amount - 3;
+            pub_input.mint_amount = mint_amount - 3u128.into();
             pub_input
         };
         assert!(mint::verify(
@@ -390,9 +391,9 @@ mod test {
         .is_err());
 
         // another instance
-        let input_amount = rng.next_u32() as u64;
-        let fee = rng.gen_range(1..input_amount);
-        let mint_amount = rng.next_u32() as u64;
+        let input_amount = AmountValue(rng.next_u64() as u128);
+        let fee = rng.gen_range(1..input_amount.0).into();
+        let mint_amount = AmountValue(rng.next_u64() as u128);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);

--- a/src/proof/mint.rs
+++ b/src/proof/mint.rs
@@ -287,9 +287,9 @@ mod test {
     fn test_pub_input_creation() -> Result<(), TxnApiError> {
         let rng = &mut ark_std::test_rng();
         let tree_depth = 2;
-        let input_amount = Amount(30);
-        let fee = Amount(10);
-        let mint_amount = Amount(15);
+        let input_amount = Amount::from(30u64);
+        let fee = Amount::from(10u64);
+        let mint_amount = Amount::from(15u64);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
@@ -312,7 +312,7 @@ mod test {
         );
 
         // negative fee should fail
-        let bad_fee = input_amount + Amount(1);
+        let bad_fee = input_amount + Amount::from(1u64);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -341,9 +341,9 @@ mod test {
         let universal_param = universal_setup_for_staging(max_degree, rng)?;
         let (proving_key, verifying_key, _) = mint::preprocess(&universal_param, tree_depth)?;
 
-        let input_amount = Amount(10);
-        let fee = Amount(4);
-        let mint_amount = Amount(35);
+        let input_amount = Amount::from(10u64);
+        let fee = Amount::from(4u64);
+        let mint_amount = Amount::from(35u64);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
@@ -391,9 +391,9 @@ mod test {
         .is_err());
 
         // another instance
-        let input_amount = Amount(rng.next_u64() as u128);
+        let input_amount = Amount::from(rng.next_u64() as u128);
         let fee = rng.gen_range(1..input_amount.0).into();
-        let mint_amount = Amount(rng.next_u64() as u128);
+        let mint_amount = Amount::from(rng.next_u64() as u128);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);

--- a/src/proof/mint.rs
+++ b/src/proof/mint.rs
@@ -20,8 +20,8 @@ use crate::{
     errors::TxnApiError,
     keys::UserKeyPair,
     structs::{
-        AmountValue, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AssetPolicy,
-        AuditMemo, InternalAssetCode, Nullifier, RecordCommitment, RecordOpening,
+        Amount, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AssetPolicy, AuditMemo,
+        InternalAssetCode, Nullifier, RecordCommitment, RecordOpening,
     },
     BaseField, CurveParam, PairingEngine, ScalarField,
 };
@@ -188,10 +188,10 @@ pub(crate) struct MintPublicInput {
     pub(crate) merkle_root: NodeValue<BaseField>,
     pub(crate) native_asset_code: AssetCode,
     pub(crate) input_nullifier: Nullifier,
-    pub(crate) fee: AmountValue,
+    pub(crate) fee: Amount,
     pub(crate) mint_rc: RecordCommitment,
     pub(crate) chg_rc: RecordCommitment,
-    pub(crate) mint_amount: AmountValue,
+    pub(crate) mint_amount: Amount,
     pub(crate) mint_ac: AssetCode,
     pub(crate) mint_internal_ac: InternalAssetCode,
     pub(crate) mint_policy: AssetPolicy,
@@ -277,7 +277,7 @@ mod test {
         errors::TxnApiError,
         keys::{AuditorKeyPair, UserKeyPair},
         proof::{mint, universal_setup_for_staging},
-        structs::AmountValue,
+        structs::Amount,
         utils::params_builder::MintParamsBuilder,
     };
     use jf_primitives::schnorr_dsa;
@@ -287,9 +287,9 @@ mod test {
     fn test_pub_input_creation() -> Result<(), TxnApiError> {
         let rng = &mut ark_std::test_rng();
         let tree_depth = 2;
-        let input_amount = AmountValue(30);
-        let fee = AmountValue(10);
-        let mint_amount = AmountValue(15);
+        let input_amount = Amount(30);
+        let fee = Amount(10);
+        let mint_amount = Amount(15);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
@@ -312,7 +312,7 @@ mod test {
         );
 
         // negative fee should fail
-        let bad_fee = input_amount + AmountValue(1);
+        let bad_fee = input_amount + Amount(1);
         let builder = MintParamsBuilder::new(
             rng,
             tree_depth,
@@ -341,9 +341,9 @@ mod test {
         let universal_param = universal_setup_for_staging(max_degree, rng)?;
         let (proving_key, verifying_key, _) = mint::preprocess(&universal_param, tree_depth)?;
 
-        let input_amount = AmountValue(10);
-        let fee = AmountValue(4);
-        let mint_amount = AmountValue(35);
+        let input_amount = Amount(10);
+        let fee = Amount(4);
+        let mint_amount = Amount(35);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);
@@ -391,9 +391,9 @@ mod test {
         .is_err());
 
         // another instance
-        let input_amount = AmountValue(rng.next_u64() as u128);
+        let input_amount = Amount(rng.next_u64() as u128);
         let fee = rng.gen_range(1..input_amount.0).into();
-        let mint_amount = AmountValue(rng.next_u64() as u128);
+        let mint_amount = Amount(rng.next_u64() as u128);
         let issuer_keypair = UserKeyPair::generate(rng);
         let receiver_keypair = UserKeyPair::generate(rng);
         let auditor_keypair = AuditorKeyPair::generate(rng);

--- a/src/proof/transfer.rs
+++ b/src/proof/transfer.rs
@@ -20,11 +20,11 @@ use crate::{
     errors::TxnApiError,
     keys::{CredIssuerPubKey, UserKeyPair},
     structs::{
-        AmountValue, AssetCode, AssetDefinition, AuditMemo, ExpirableCredential, Nullifier,
+        Amount, AssetCode, AssetDefinition, AuditMemo, ExpirableCredential, Nullifier,
         RecordCommitment, RecordOpening,
     },
     transfer::TransferNoteInput,
-    utils::safe_sum_amount_value,
+    utils::safe_sum_amount,
     BaseField, CurveParam, PairingEngine, ScalarField,
 };
 use ark_serialize::*;
@@ -321,7 +321,7 @@ pub(crate) struct TransferPublicInput {
     pub(crate) merkle_root: NodeValue<BaseField>,
     pub(crate) native_asset_code: AssetCode,
     pub(crate) valid_until: u64,
-    pub(crate) fee: AmountValue,
+    pub(crate) fee: Amount,
     pub(crate) input_nullifiers: Vec<Nullifier>,
     pub(crate) output_commitments: Vec<RecordCommitment>,
     pub(crate) audit_memo: AuditMemo,
@@ -355,27 +355,27 @@ impl TransferPublicInput {
         // input - sum of output) is the fee; when the transfer type is
         // non-native asset type, the amount for the transferred type should be
         // net neutral, thus the same calculation can correctly derive the fee.
-        let input_sum: AmountValue = safe_sum_amount_value(
+        let input_sum: Amount = safe_sum_amount(
             witness
                 .input_secrets
                 .iter()
                 .filter(|x| !x.ro.asset_def.is_dummy())
                 .map(|x| x.ro.amount)
-                .collect::<Vec<AmountValue>>()
+                .collect::<Vec<Amount>>()
                 .as_slice(),
         )
         .ok_or_else(|| TxnApiError::InvalidParameter("Sum overflow for inputs.".to_string()))?;
-        let output_sum: AmountValue = safe_sum_amount_value(
+        let output_sum: Amount = safe_sum_amount(
             witness
                 .output_record_openings
                 .iter()
                 .map(|x| x.amount)
-                .collect::<Vec<AmountValue>>()
+                .collect::<Vec<Amount>>()
                 .as_slice(),
         )
         .ok_or_else(|| TxnApiError::InvalidParameter("Sum overflow for outputs.".to_string()))?;
 
-        let fee = AmountValue(u128::checked_sub(input_sum.0, output_sum.0).ok_or_else(|| {
+        let fee = Amount(u128::checked_sub(input_sum.0, output_sum.0).ok_or_else(|| {
             TxnApiError::InvalidParameter("The fee cannot be negative".to_string())
         })?);
 
@@ -460,7 +460,7 @@ mod test {
         errors::TxnApiError,
         keys::{CredIssuerPubKey, UserAddress, UserKeyPair},
         proof::universal_setup_for_staging,
-        structs::{AmountValue, AssetDefinition, ExpirableCredential},
+        structs::{Amount, AssetDefinition, ExpirableCredential},
         utils::params_builder::TransferParamsBuilder,
     };
     use ark_std::vec;
@@ -485,7 +485,7 @@ mod test {
         // transfer non-native asset type
         let builder = TransferParamsBuilder::new_non_native(2, 6, None, user_keypairs)
             .set_input_amounts(30.into(), &[25.into()])
-            .set_output_amounts(19.into(), &AmountValue::from_vec(&[3, 4, 5, 6, 7])[..])
+            .set_output_amounts(19.into(), &Amount::from_vec(&[3, 4, 5, 6, 7])[..])
             .set_input_creds(cred_expiry);
         let witness = builder.build_witness(rng);
 
@@ -525,8 +525,8 @@ mod test {
         let user_keypair = UserKeyPair::generate(rng);
         let user_keypairs = vec![&user_keypair; 2];
         let builder = TransferParamsBuilder::new_native(2, 3, None, user_keypairs)
-            .set_input_amounts(20.into(), &AmountValue::from_vec(&[10])[..])
-            .set_output_amounts(14.into(), &AmountValue::from_vec(&[4, 6])[..])
+            .set_input_amounts(20.into(), &Amount::from_vec(&[10])[..])
+            .set_output_amounts(14.into(), &Amount::from_vec(&[4, 6])[..])
             .set_input_creds(cred_expiry);
         let witness = builder.build_witness(rng);
         // check asset_def
@@ -543,8 +543,8 @@ mod test {
         let user_keypairs = vec![&user_keypair; 2];
         // transfer non-native asset type
         let builder = TransferParamsBuilder::new_non_native(2, 3, None, user_keypairs)
-            .set_input_amounts(30.into(), &AmountValue::from_vec(&[10])[..])
-            .set_output_amounts(19.into(), &AmountValue::from_vec(&[4, 6])[..])
+            .set_input_amounts(30.into(), &Amount::from_vec(&[10])[..])
+            .set_output_amounts(19.into(), &Amount::from_vec(&[4, 6])[..])
             .set_input_creds(cred_expiry);
         let witness = builder.build_witness(rng);
         assert!(
@@ -570,7 +570,7 @@ mod test {
 
         // overflow total input amounts should fail
         let mut bad_witness = witness.clone();
-        bad_witness.input_secrets[1].ro.amount = AmountValue(u128::MAX - 1);
+        bad_witness.input_secrets[1].ro.amount = Amount(u128::MAX - 1);
         assert!(
             TransferPublicInput::from_witness(&bad_witness, valid_until).is_err(),
             "create public input from wrong witness with overflown total input amounts should fail"
@@ -578,7 +578,7 @@ mod test {
 
         // overflow total output amounts should fail
         let mut bad_witness = witness.clone();
-        bad_witness.output_record_openings[1].amount = AmountValue(u128::MAX - 13);
+        bad_witness.output_record_openings[1].amount = Amount(u128::MAX - 13);
         assert!(TransferPublicInput::from_witness(
             &bad_witness,
             valid_until,
@@ -616,8 +616,8 @@ mod test {
             Some(depth),
             user_keypairs,
         )
-        .set_input_amounts(30.into(), &AmountValue::from_vec(&[25])[..])
-        .set_output_amounts(19.into(), &AmountValue::from_vec(&[3, 4, 5, 6, 7])[..])
+        .set_input_amounts(30.into(), &Amount::from_vec(&[25])[..])
+        .set_output_amounts(19.into(), &Amount::from_vec(&[3, 4, 5, 6, 7])[..])
         .set_input_creds(cred_expiry);
         let witness_1 = builder.build_witness(rng);
         let pub_input_1 = TransferPublicInput::from_witness(&witness_1, valid_until)?;
@@ -655,8 +655,8 @@ mod test {
         let user_keypairs = vec![&user_keypair; 1];
         let builder =
             TransferParamsBuilder::new_native(num_input, num_output, Some(depth), user_keypairs)
-                .set_input_amounts(30.into(), &AmountValue::from_vec(&[])[..])
-                .set_output_amounts(13.into(), &AmountValue::from_vec(&[15])[..])
+                .set_input_amounts(30.into(), &Amount::from_vec(&[])[..])
+                .set_output_amounts(13.into(), &Amount::from_vec(&[15])[..])
                 .set_input_creds(cred_expiry);
         let witness_2 = builder.build_witness(rng);
         let pub_input_2 = TransferPublicInput::from_witness(&witness_2, valid_until)?;

--- a/src/proof/transfer.rs
+++ b/src/proof/transfer.rs
@@ -231,7 +231,7 @@ impl<'a> TransferWitness<'a> {
         let asset_def = AssetDefinition::native();
         let input_secret = {
             let ro = RecordOpening {
-                amount: 0.into(),
+                amount: 0u64.into(),
                 asset_def: asset_def.clone(),
                 pub_key: Default::default(),
                 freeze_flag: Default::default(),
@@ -375,7 +375,7 @@ impl TransferPublicInput {
         )
         .ok_or_else(|| TxnApiError::InvalidParameter("Sum overflow for outputs.".to_string()))?;
 
-        let fee = Amount(u128::checked_sub(input_sum.0, output_sum.0).ok_or_else(|| {
+        let fee = Amount::from(u128::checked_sub(input_sum.0, output_sum.0).ok_or_else(|| {
             TxnApiError::InvalidParameter("The fee cannot be negative".to_string())
         })?);
 
@@ -484,8 +484,8 @@ mod test {
         let user_keypairs = vec![&user_keypair; 2];
         // transfer non-native asset type
         let builder = TransferParamsBuilder::new_non_native(2, 6, None, user_keypairs)
-            .set_input_amounts(30.into(), &[25.into()])
-            .set_output_amounts(19.into(), &Amount::from_vec(&[3, 4, 5, 6, 7])[..])
+            .set_input_amounts(30u64.into(), &[25u64.into()])
+            .set_output_amounts(19u64.into(), &Amount::from_vec(&[3, 4, 5, 6, 7])[..])
             .set_input_creds(cred_expiry);
         let witness = builder.build_witness(rng);
 
@@ -525,8 +525,8 @@ mod test {
         let user_keypair = UserKeyPair::generate(rng);
         let user_keypairs = vec![&user_keypair; 2];
         let builder = TransferParamsBuilder::new_native(2, 3, None, user_keypairs)
-            .set_input_amounts(20.into(), &Amount::from_vec(&[10])[..])
-            .set_output_amounts(14.into(), &Amount::from_vec(&[4, 6])[..])
+            .set_input_amounts(20u64.into(), &Amount::from_vec(&[10])[..])
+            .set_output_amounts(14u64.into(), &Amount::from_vec(&[4, 6])[..])
             .set_input_creds(cred_expiry);
         let witness = builder.build_witness(rng);
         // check asset_def
@@ -543,8 +543,8 @@ mod test {
         let user_keypairs = vec![&user_keypair; 2];
         // transfer non-native asset type
         let builder = TransferParamsBuilder::new_non_native(2, 3, None, user_keypairs)
-            .set_input_amounts(30.into(), &Amount::from_vec(&[10])[..])
-            .set_output_amounts(19.into(), &Amount::from_vec(&[4, 6])[..])
+            .set_input_amounts(30u64.into(), &Amount::from_vec(&[10])[..])
+            .set_output_amounts(19u64.into(), &Amount::from_vec(&[4, 6])[..])
             .set_input_creds(cred_expiry);
         let witness = builder.build_witness(rng);
         assert!(
@@ -562,7 +562,7 @@ mod test {
 
         // negative fee should fail
         let mut bad_witness = witness.clone();
-        bad_witness.output_record_openings[0].amount = 31.into();
+        bad_witness.output_record_openings[0].amount = 31u64.into();
         assert!(
             TransferPublicInput::from_witness(&bad_witness, valid_until).is_err(),
             "create public input from wrong witness with negative fee should fail"
@@ -570,7 +570,7 @@ mod test {
 
         // overflow total input amounts should fail
         let mut bad_witness = witness.clone();
-        bad_witness.input_secrets[1].ro.amount = Amount(u128::MAX - 1);
+        bad_witness.input_secrets[1].ro.amount = Amount::from(u128::MAX - 1);
         assert!(
             TransferPublicInput::from_witness(&bad_witness, valid_until).is_err(),
             "create public input from wrong witness with overflown total input amounts should fail"
@@ -578,7 +578,7 @@ mod test {
 
         // overflow total output amounts should fail
         let mut bad_witness = witness.clone();
-        bad_witness.output_record_openings[1].amount = Amount(u128::MAX - 13);
+        bad_witness.output_record_openings[1].amount = Amount::from(u128::MAX - 13);
         assert!(TransferPublicInput::from_witness(
             &bad_witness,
             valid_until,
@@ -616,8 +616,8 @@ mod test {
             Some(depth),
             user_keypairs,
         )
-        .set_input_amounts(30.into(), &Amount::from_vec(&[25])[..])
-        .set_output_amounts(19.into(), &Amount::from_vec(&[3, 4, 5, 6, 7])[..])
+        .set_input_amounts(30u64.into(), &Amount::from_vec(&[25])[..])
+        .set_output_amounts(19u64.into(), &Amount::from_vec(&[3, 4, 5, 6, 7])[..])
         .set_input_creds(cred_expiry);
         let witness_1 = builder.build_witness(rng);
         let pub_input_1 = TransferPublicInput::from_witness(&witness_1, valid_until)?;
@@ -655,8 +655,8 @@ mod test {
         let user_keypairs = vec![&user_keypair; 1];
         let builder =
             TransferParamsBuilder::new_native(num_input, num_output, Some(depth), user_keypairs)
-                .set_input_amounts(30.into(), &Amount::from_vec(&[])[..])
-                .set_output_amounts(13.into(), &Amount::from_vec(&[15])[..])
+                .set_input_amounts(30u64.into(), &Amount::from_vec(&[])[..])
+                .set_output_amounts(13u64.into(), &Amount::from_vec(&[15])[..])
                 .set_input_creds(cred_expiry);
         let witness_2 = builder.build_witness(rng);
         let pub_input_2 = TransferPublicInput::from_witness(&witness_2, valid_until)?;

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -107,7 +107,13 @@ impl From<&AssetCode> for BaseField {
     }
 }
 
-/// Amount value type
+/// Record Amount type
+/// # How to convert between unsigned int types
+/// ```ignore
+/// let a = Amount::from(10u64);
+/// let b : Amount = 8u32.into();
+/// let c : u128 = a.into();
+/// ```
 #[derive(
     Debug,
     Clone,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1949,8 +1949,35 @@ mod test {
     }
 
     #[test]
+    fn test_amount_value_arithmetics() {
+        let rng = &mut ark_std::test_rng();
+        let a = u64::rand(rng) as u128 / 2;
+        let a_amount = AmountValue::from(a);
+        let b = a + u32::rand(rng) as u128;
+        let b_amount = AmountValue::from(b);
+        let c = a + b;
+        let c_amount = a_amount + b_amount;
+        assert_eq!(c_amount, c.into());
+        let c = b - a;
+        let c_amount = b_amount - a_amount;
+        assert_eq!(c_amount, c.into());
+        let c = b * a;
+        let c_amount = b_amount * a;
+        assert_eq!(c_amount, c.into());
+        let c = b / a;
+        let c_amount = b_amount / a;
+        assert_eq!(c_amount, c.into());
+    }
+
+    #[test]
     fn test_serde() {
         let mut rng = ark_std::test_rng();
+
+        // amount value related
+        let amount_value = AmountValue::from(u128::rand(&mut rng));
+        let ser_bytes = bincode::serialize(&amount_value).unwrap();
+        let amount_value_rec: AmountValue = bincode::deserialize(&ser_bytes[..]).unwrap();
+        assert_eq!(amount_value, amount_value_rec);
 
         // asset code related
         let asset_code_seed = AssetCodeSeed::generate(&mut rng);

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -133,6 +133,7 @@ impl From<&AssetCode> for BaseField {
     Ord,
     Sum,
 )]
+#[from(types(u64, u32, u8))]
 pub struct Amount(pub(crate) u128);
 
 impl Amount {
@@ -485,7 +486,7 @@ impl AssetPolicy {
 
     /// True if `reveal_threshold` is not the default value, false otherwise
     pub fn is_reveal_threshold_set(&self) -> bool {
-        self.reveal_threshold != Amount(0)
+        self.reveal_threshold != Amount::from(0u64)
     }
 
     /// Set the auditor public key
@@ -917,7 +918,7 @@ impl RecordOpening {
         (
             Self::new(
                 rng,
-                Amount(0),
+                Amount::from(0u64),
                 AssetDefinition::dummy(),
                 pub_key,
                 freeze_flag,
@@ -1433,7 +1434,7 @@ impl AuditData {
             }
             let mut amount_bytes = [0u8; 16];
             amount_bytes.copy_from_slice(&big_int.to_bytes_le()[0..16]);
-            Some(Amount(u128::from_le_bytes(amount_bytes)))
+            Some(Amount::from(u128::from_le_bytes(amount_bytes)))
         } else {
             None
         };
@@ -1685,9 +1686,9 @@ mod test {
             let universal_param = universal_setup_for_staging(max_degree, rng)?;
             let (proving_key, ..) = proof::mint::preprocess(&universal_param, tree_depth)?;
 
-            let input_amount = Amount(10);
-            let fee = Amount(4);
-            let mint_amount = Amount(35);
+            let input_amount = Amount::from(10u64);
+            let fee = Amount::from(4u64);
+            let mint_amount = Amount::from(35u64);
             let issuer_keypair = UserKeyPair::generate(rng);
             let receiver_keypair = UserKeyPair::generate(rng);
             let auditor_keypair = AuditorKeyPair::generate(rng);
@@ -1991,7 +1992,7 @@ mod test {
 
         let ro = RecordOpening::new(
             &mut rng,
-            Amount(23),
+            Amount::from(23u64),
             asset_def,
             user_keypair.pub_key(),
             FreezeFlag::Unfrozen,
@@ -2016,7 +2017,7 @@ mod test {
             asset_def.policy.auditor_pk = AuditorPubKey::default();
             let ro = RecordOpening::new(
                 &mut rng,
-                Amount(23),
+                Amount::from(23u64),
                 asset_def.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -108,7 +108,6 @@ impl From<&AssetCode> for BaseField {
 }
 
 /// Amount value type
-#[tagged_blob("AMOUNT_VALUE")]
 #[derive(
     Debug,
     Clone,
@@ -132,7 +131,13 @@ impl From<&AssetCode> for BaseField {
     PartialOrd,
     Ord,
     Sum,
+    Deserialize,
+    Serialize,
+    Display,
+    FromStr,
+    LowerHex,
 )]
+#[serde(from = "u128", into = "u128")]
 #[from(types(u64, u32, u8))]
 pub struct Amount(pub(crate) u128);
 

--- a/src/testing_apis.rs
+++ b/src/testing_apis.rs
@@ -19,7 +19,7 @@
 use crate::{
     errors::TxnApiError,
     proof::{self, freeze::FreezeVerifyingKey, transfer::TransferVerifyingKey},
-    structs::{AmountValue, AssetCode, AuditMemo, Nullifier, RecordCommitment},
+    structs::{Amount, AssetCode, AuditMemo, Nullifier, RecordCommitment},
     transfer::TransferNote,
     BaseField, MintVerifyingKey, PairingEngine,
 };
@@ -55,7 +55,7 @@ pub struct TransferPublicInput {
     pub merkle_root: NodeValue<BaseField>,
     pub native_asset_code: AssetCode,
     pub valid_until: u64,
-    pub fee: AmountValue,
+    pub fee: Amount,
     pub input_nullifiers: Vec<Nullifier>,
     pub output_commitments: Vec<RecordCommitment>,
     pub audit_memo: AuditMemo,

--- a/src/testing_apis.rs
+++ b/src/testing_apis.rs
@@ -19,14 +19,13 @@
 use crate::{
     errors::TxnApiError,
     proof::{self, freeze::FreezeVerifyingKey, transfer::TransferVerifyingKey},
-    structs::{AssetCode, AuditMemo, Nullifier, RecordCommitment},
+    structs::{AmountValue, AssetCode, AuditMemo, Nullifier, RecordCommitment},
     transfer::TransferNote,
     BaseField, MintVerifyingKey, PairingEngine,
 };
 use ark_std::vec::Vec;
 use jf_plonk::proof_system::structs::VerifyingKey;
 use jf_primitives::merkle_tree::NodeValue;
-use rand::{CryptoRng, RngCore};
 
 impl MintVerifyingKey {
     /// Expose the verifying key
@@ -56,7 +55,7 @@ pub struct TransferPublicInput {
     pub merkle_root: NodeValue<BaseField>,
     pub native_asset_code: AssetCode,
     pub valid_until: u64,
-    pub fee: u64,
+    pub fee: AmountValue,
     pub input_nullifiers: Vec<Nullifier>,
     pub output_commitments: Vec<RecordCommitment>,
     pub audit_memo: AuditMemo,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -18,11 +18,11 @@ use crate::{
         TransferWitness,
     },
     structs::{
-        AssetCode, AssetDefinition, AuditMemo, ExpirableCredential, FeeInput, FreezeFlag,
-        Nullifier, RecordCommitment, RecordOpening, TxnFeeInfo,
+        AmountValue, AssetCode, AssetDefinition, AuditMemo, ExpirableCredential, FeeInput,
+        FreezeFlag, Nullifier, RecordCommitment, RecordOpening, TxnFeeInfo,
     },
     utils::{
-        safe_sum_u64,
+        safe_sum_amount_value,
         txn_helpers::{transfer::*, *},
     },
     AccMemberWitness, KeyPair, NodeValue, VerKey,
@@ -81,7 +81,7 @@ pub struct AuxInfo {
     /// Accumulator state
     pub merkle_root: NodeValue,
     /// proposed fee in native asset type for the transfer
-    pub fee: u64,
+    pub fee: AmountValue,
     /// A projected future timestamp that the snark proof should be valid until,
     /// especially for credential to still hold valid/unexpired
     pub valid_until: u64,
@@ -137,7 +137,7 @@ impl TransferNote {
         rng: &mut R,
         inputs: Vec<TransferNoteInput<'a>>,
         outputs: &[RecordOpening],
-        fee: u64,
+        fee: AmountValue,
         valid_until: u64,
         proving_key: &TransferProvingKey<'a>,
     ) -> Result<(Self, KeyPair, RecordOpening), TxnApiError>
@@ -163,13 +163,13 @@ impl TransferNote {
             .filter(|input| !input.ro.is_dummy())
             .map(|input| input.ro.amount)
             .collect();
-        let total_in = safe_sum_u64(&in_amounts).ok_or_else(|| {
+        let total_in = safe_sum_amount_value(&in_amounts).ok_or_else(|| {
             TxnApiError::InvalidParameter(
                 "Total input amount exceeds max value (2^64-1)".to_string(),
             )
         })?;
         let out_amounts: Vec<_> = outputs.iter().map(|output| output.amount).collect();
-        let total_out = safe_sum_u64(&out_amounts).ok_or_else(|| {
+        let total_out = safe_sum_amount_value(&out_amounts).ok_or_else(|| {
             TxnApiError::InvalidParameter(
                 "Total output amount exceeds max value (2^64-1)".to_string(),
             )
@@ -392,7 +392,7 @@ mod tests {
             transfer::{preprocess, TransferProvingKey, TransferVerifyingKey},
             universal_setup_for_staging,
         },
-        structs::{AssetDefinition, ExpirableCredential, NoteType},
+        structs::{AmountValue, AssetDefinition, ExpirableCredential, NoteType},
         transfer::TransferNote,
         utils::{
             compute_universal_param_size,
@@ -424,8 +424,8 @@ mod tests {
         // ====================================
         // a transfer with 0 fee
         // ====================================
-        let input_amounts = [30, 25];
-        let output_amounts = [30, 3, 4, 5, 6, 7];
+        let input_amounts = AmountValue::from_vec(&[30, 25]);
+        let output_amounts = AmountValue::from_vec(&[30, 3, 4, 5, 6, 7]);
 
         let mut builder = test_anon_xfr_helper(
             &input_amounts,
@@ -444,8 +444,8 @@ mod tests {
         // ====================================
         // a normal transfer
         // ====================================
-        let input_amounts = [30, 25];
-        let output_amounts = [19, 3, 4, 5, 6, 7];
+        let input_amounts = AmountValue::from_vec(&[30, 25]);
+        let output_amounts = AmountValue::from_vec(&[19, 3, 4, 5, 6, 7]);
 
         let _builder = test_anon_xfr_helper(
             &input_amounts,
@@ -517,11 +517,12 @@ mod tests {
             )
             .is_err());
         builder.output_ros = vec![]; // prune all output and reset
-        let builder = builder.set_output_amounts(19, &[3, 4, 5, 6, 7]);
+        let builder =
+            builder.set_output_amounts(19.into(), &AmountValue::from_vec(&[3, 4, 5, 6, 7])[..]);
 
         // 3.invalid inputs/outputs
         let mut builder = builder;
-        builder.input_ros[0].amount += 1;
+        builder.input_ros[0].amount += AmountValue(1);
         assert!(builder
             .build_transfer_note(
                 &mut prng,
@@ -530,7 +531,7 @@ mod tests {
                 extra_proof_bound_data.clone()
             )
             .is_err());
-        builder.input_ros[0].amount -= 1;
+        builder.input_ros[0].amount -= AmountValue(1);
 
         // 4. inconsistent MT roots
         let mut mt_info = builder.input_acc_member_witnesses[0].clone();
@@ -594,8 +595,8 @@ mod tests {
                 Some(depth),
                 vec![&keypair; num_input],
             )
-            .set_input_amounts(30, &[20, 10])
-            .set_output_amounts(19, &[20, 10])
+            .set_input_amounts(AmountValue(30), &[AmountValue(20), AmountValue(10)])
+            .set_output_amounts(AmountValue(19), &[AmountValue(20), AmountValue(10)])
             .set_input_creds(cred_expiry)
             .update_input_asset_def(1, second_asset_def.clone())
             .update_output_asset_def(1, second_asset_def);
@@ -614,8 +615,8 @@ mod tests {
     }
 
     fn test_anon_xfr_helper<'a>(
-        input_amounts: &[u64],
-        output_amounts: &[u64],
+        input_amounts: &[AmountValue],
+        output_amounts: &[AmountValue],
         keypair1: &'a UserKeyPair,
         keypair2: &'a UserKeyPair,
         depth: u8,
@@ -723,10 +724,10 @@ mod tests {
         let srs = universal_setup_for_staging(domain_size, &mut prng).unwrap();
         let (prover_key, verifier_key, _) = preprocess(&srs, num_input, num_output, depth).unwrap();
 
-        let fee_input = 30;
-        let fee_chg = 19;
-        let input_amounts = [10, 0, 20];
-        let output_amounts = [2, 3, 4, 5, 16];
+        let fee_input = AmountValue(30);
+        let fee_chg = AmountValue(19);
+        let input_amounts = AmountValue::from_vec(&[10, 0, 20]);
+        let output_amounts = AmountValue::from_vec(&[2, 3, 4, 5, 16]);
 
         let keypair1 = UserKeyPair::generate(&mut prng);
         let keypair2 = UserKeyPair::generate(&mut prng);

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -518,11 +518,11 @@ mod tests {
             .is_err());
         builder.output_ros = vec![]; // prune all output and reset
         let builder =
-            builder.set_output_amounts(19.into(), &Amount::from_vec(&[3, 4, 5, 6, 7])[..]);
+            builder.set_output_amounts(19u64.into(), &Amount::from_vec(&[3, 4, 5, 6, 7])[..]);
 
         // 3.invalid inputs/outputs
         let mut builder = builder;
-        builder.input_ros[0].amount += Amount(1);
+        builder.input_ros[0].amount += Amount::from(1u64);
         assert!(builder
             .build_transfer_note(
                 &mut prng,
@@ -531,7 +531,7 @@ mod tests {
                 extra_proof_bound_data.clone()
             )
             .is_err());
-        builder.input_ros[0].amount -= Amount(1);
+        builder.input_ros[0].amount -= Amount::from(1u64);
 
         // 4. inconsistent MT roots
         let mut mt_info = builder.input_acc_member_witnesses[0].clone();
@@ -595,8 +595,14 @@ mod tests {
                 Some(depth),
                 vec![&keypair; num_input],
             )
-            .set_input_amounts(Amount(30), &[Amount(20), Amount(10)])
-            .set_output_amounts(Amount(19), &[Amount(20), Amount(10)])
+            .set_input_amounts(
+                Amount::from(30u64),
+                &[Amount::from(20u64), Amount::from(10u64)],
+            )
+            .set_output_amounts(
+                Amount::from(19u64),
+                &[Amount::from(20u64), Amount::from(10u64)],
+            )
             .set_input_creds(cred_expiry)
             .update_input_asset_def(1, second_asset_def.clone())
             .update_output_asset_def(1, second_asset_def);
@@ -724,8 +730,8 @@ mod tests {
         let srs = universal_setup_for_staging(domain_size, &mut prng).unwrap();
         let (prover_key, verifier_key, _) = preprocess(&srs, num_input, num_output, depth).unwrap();
 
-        let fee_input = Amount(30);
-        let fee_chg = Amount(19);
+        let fee_input = Amount::from(30u64);
+        let fee_chg = Amount::from(19u64);
         let input_amounts = Amount::from_vec(&[10, 0, 20]);
         let output_amounts = Amount::from_vec(&[2, 3, 4, 5, 16]);
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -202,7 +202,7 @@ mod tests {
 
         let ro_1 = RecordOpening::new(
             &mut rng,
-            23.into(),
+            23u64.into(),
             asset_def_native.clone(),
             user_keypair.pub_key(),
             FreezeFlag::Unfrozen,
@@ -210,7 +210,7 @@ mod tests {
 
         let ro_2 = RecordOpening::new(
             &mut rng,
-            23.into(),
+            23u64.into(),
             asset_def_2.clone(),
             user_keypair.pub_key(),
             FreezeFlag::Unfrozen,
@@ -218,7 +218,7 @@ mod tests {
 
         let ro_3 = RecordOpening::new(
             &mut rng,
-            23.into(),
+            23u64.into(),
             asset_def_3.clone(),
             user_keypair.pub_key(),
             FreezeFlag::Unfrozen,
@@ -757,7 +757,7 @@ pub(crate) mod txn_helpers {
         if inputs
             .iter()
             .skip(1)
-            .any(|input| input.asset_def.is_dummy() && input.amount != Amount(0))
+            .any(|input| input.asset_def.is_dummy() && input.amount != Amount::from(0u32))
         {
             Err(TxnApiError::InvalidParameter(
                 "Dummy inputs must have 0 amount".to_string(),
@@ -806,7 +806,7 @@ pub(crate) mod txn_helpers {
 
             let ro_in_1 = RecordOpening::new(
                 &mut rng,
-                10.into(),
+                10u64.into(),
                 asset_def_native.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -814,7 +814,7 @@ pub(crate) mod txn_helpers {
 
             let ro_out_1 = RecordOpening::new(
                 &mut rng,
-                5.into(),
+                5u64.into(),
                 asset_def_native.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -822,7 +822,7 @@ pub(crate) mod txn_helpers {
 
             let inputs = [&ro_in_1];
             let outputs = [&ro_out_1];
-            assert_eq!(derive_fee(&inputs, &outputs).unwrap(), 5.into());
+            assert_eq!(derive_fee(&inputs, &outputs).unwrap(), 5u64.into());
 
             // input amount is lower than output amount
             assert!(derive_fee(&outputs, &inputs).is_err());
@@ -830,7 +830,7 @@ pub(crate) mod txn_helpers {
             // Many records openings, all of which are native
             let ro_in_2 = RecordOpening::new(
                 &mut rng,
-                7.into(),
+                7u64.into(),
                 asset_def_native.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -838,7 +838,7 @@ pub(crate) mod txn_helpers {
 
             let ro_out_2 = RecordOpening::new(
                 &mut rng,
-                5.into(),
+                5u64.into(),
                 asset_def_native.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -846,7 +846,7 @@ pub(crate) mod txn_helpers {
 
             let ro_out_3 = RecordOpening::new(
                 &mut rng,
-                6.into(),
+                6u64.into(),
                 asset_def_native.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -854,7 +854,7 @@ pub(crate) mod txn_helpers {
 
             let inputs = [&ro_in_1, &ro_in_2];
             let outputs = [&ro_out_1, &ro_out_2, &ro_out_3];
-            assert_eq!(derive_fee(&inputs, &outputs).unwrap(), 1.into());
+            assert_eq!(derive_fee(&inputs, &outputs).unwrap(), 1u64.into());
 
             // input amount is lower than output amount
             assert!(derive_fee(&outputs, &inputs).is_err());
@@ -862,7 +862,7 @@ pub(crate) mod txn_helpers {
             // Many records openings, some of which are non native
             let ro_in_non_native = RecordOpening::new(
                 &mut rng,
-                7.into(),
+                7u64.into(),
                 asset_def_non_native.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -870,7 +870,7 @@ pub(crate) mod txn_helpers {
 
             let ro_out_non_native = RecordOpening::new(
                 &mut rng,
-                7.into(),
+                7u64.into(),
                 asset_def_non_native.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -878,7 +878,7 @@ pub(crate) mod txn_helpers {
 
             let inputs = [&ro_in_1, &ro_in_non_native];
             let outputs = [&ro_out_1, &ro_out_non_native];
-            assert_eq!(derive_fee(&inputs, &outputs).unwrap(), 5.into());
+            assert_eq!(derive_fee(&inputs, &outputs).unwrap(), 5u64.into());
 
             // input amount is lower than output amount
             assert!(derive_fee(&outputs, &inputs).is_err());
@@ -909,7 +909,7 @@ pub(crate) mod txn_helpers {
 
             let ro_in_non_native = RecordOpening::new(
                 &mut rng,
-                10.into(),
+                10u64.into(),
                 asset_def_non_native_1.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -917,7 +917,7 @@ pub(crate) mod txn_helpers {
 
             let ro_in_native = RecordOpening::new(
                 &mut rng,
-                10.into(),
+                10u64.into(),
                 asset_def_native.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -926,7 +926,7 @@ pub(crate) mod txn_helpers {
             let ro_in_asset_1 = ro_in_non_native.clone();
             let ro_in_asset_2 = RecordOpening::new(
                 &mut rng,
-                10.into(),
+                10u64.into(),
                 asset_def_non_native_2.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -934,7 +934,7 @@ pub(crate) mod txn_helpers {
 
             let ro_in_non_native_bad_policy = RecordOpening::new(
                 &mut rng,
-                5.into(),
+                5u64.into(),
                 asset_def_freezer_key_non_null_tracer_key_null.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -942,7 +942,7 @@ pub(crate) mod txn_helpers {
 
             let ro_out_native = RecordOpening::new(
                 &mut rng,
-                5.into(),
+                5u64.into(),
                 asset_def_native.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -950,7 +950,7 @@ pub(crate) mod txn_helpers {
 
             let ro_out_non_native = RecordOpening::new(
                 &mut rng,
-                5.into(),
+                5u64.into(),
                 asset_def_non_native_1.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -958,7 +958,7 @@ pub(crate) mod txn_helpers {
 
             let ro_out_non_native_bad_policy = RecordOpening::new(
                 &mut rng,
-                5.into(),
+                5u64.into(),
                 asset_def_freezer_key_non_null_tracer_key_null.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,
@@ -967,7 +967,7 @@ pub(crate) mod txn_helpers {
             let ro_out_asset_1 = ro_out_non_native.clone();
             let ro_out_asset_2 = RecordOpening::new(
                 &mut rng,
-                5.into(),
+                5u64.into(),
                 asset_def_non_native_2.clone(),
                 user_keypair.pub_key(),
                 FreezeFlag::Unfrozen,

--- a/src/utils/params_builder.rs
+++ b/src/utils/params_builder.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     sign_receiver_memos,
     structs::{
-        AmountValue, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AssetPolicy,
+        Amount, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AssetPolicy,
         ExpirableCredential, FeeInput, FreezeFlag, IdentityAttribute, NoteType, ReceiverMemo,
         RecordOpening, RevealMap, TxnFeeInfo,
     },
@@ -432,7 +432,7 @@ impl<'a> TransferParamsBuilder<'a> {
         self.refresh_merkle_root()
     }
 
-    pub(crate) fn set_reveal_threshold(mut self, reveal_threshold: AmountValue) -> Self {
+    pub(crate) fn set_reveal_threshold(mut self, reveal_threshold: Amount) -> Self {
         assert!(
             self.transfer_asset_def.is_some(),
             "reveal_threshold cannot be set on native asset"
@@ -478,7 +478,7 @@ impl<'a> TransferParamsBuilder<'a> {
     ///   overall left over amount
     /// * `amounts` - list of input amounts (the first amount corresponds to the
     ///   native asset)
-    pub fn set_input_amounts(mut self, fee_input: AmountValue, amounts: &[AmountValue]) -> Self {
+    pub fn set_input_amounts(mut self, fee_input: Amount, amounts: &[Amount]) -> Self {
         assert!(self.input_ros.is_empty(), "Input records already set");
         assert_eq!(
             amounts.len() + 1,
@@ -521,7 +521,7 @@ impl<'a> TransferParamsBuilder<'a> {
     /// Define the outputs amounts of a Transfer note
     /// * `amounts` - list of input amounts (the first amount corresponds to the
     ///   native asset)
-    pub fn set_output_amounts(mut self, fee_chg: AmountValue, amounts: &[AmountValue]) -> Self {
+    pub fn set_output_amounts(mut self, fee_chg: Amount, amounts: &[Amount]) -> Self {
         assert!(self.output_ros.is_empty(), "Output records already set");
         assert_eq!(
             amounts.len() + 1,
@@ -646,7 +646,7 @@ impl<'a> TransferParamsBuilder<'a> {
     pub(crate) fn set_dummy_input_record(mut self, index: usize) -> Self {
         assert!(index < self.input_ros.len());
         self.input_ros[index + 1].asset_def = AssetDefinition::dummy(); // first position is reserved for input fee
-        self.input_ros[index + 1].amount = AmountValue(0);
+        self.input_ros[index + 1].amount = Amount(0);
         // self.input_ros[index + 1].pub_key.address = Default::default();
         self.refresh_merkle_root()
     }
@@ -666,12 +666,12 @@ impl<'a> TransferParamsBuilder<'a> {
         self
     }
 
-    pub(crate) fn update_fee_input_amount(mut self, amount: AmountValue) -> Self {
+    pub(crate) fn update_fee_input_amount(mut self, amount: Amount) -> Self {
         self.input_ros[0].amount = amount;
         self.refresh_merkle_root()
     }
 
-    pub(crate) fn update_input_amount(mut self, index: usize, amount: AmountValue) -> Self {
+    pub(crate) fn update_input_amount(mut self, index: usize, amount: Amount) -> Self {
         assert!(index < self.input_ros.len());
         self.input_ros[index + 1].amount = amount;
         self.refresh_merkle_root()
@@ -695,9 +695,9 @@ impl<'a> TransferParamsBuilder<'a> {
         let cred_expiry = rng.gen_range(valid_until + 1..2000);
         // guarantee: fee change < fee, the rest reserve balances
         let (fee_input, input_amounts, fee_chg, output_amounts) = {
-            let fee = AmountValue(rng.gen_range(1..20));
-            let fee_change = AmountValue(rng.gen_range(1..=fee.0));
-            let transfer_amount = AmountValue(
+            let fee = Amount(rng.gen_range(1..20));
+            let fee_change = Amount(rng.gen_range(1..=fee.0));
+            let transfer_amount = Amount(
                 rng.gen_range(1..50) * (num_input as u128 - 1) * (num_output as u128 - 1) as u128,
             );
             let input_amounts = vec![transfer_amount / (num_input as u128 - 1); num_input - 1];
@@ -905,7 +905,7 @@ pub struct MintParamsBuilder<'a> {
     tree_depth: u8,
     pub(crate) issuer_keypair: &'a UserKeyPair,
     pub(crate) fee_ro: RecordOpening,
-    pub(crate) fee: AmountValue,
+    pub(crate) fee: Amount,
     pub(crate) mint_ro: RecordOpening,
     pub(crate) ac_seed: AssetCodeSeed,
     pub(crate) ac_description: Vec<u8>,
@@ -921,9 +921,9 @@ impl<'a> MintParamsBuilder<'a> {
     pub fn new<R>(
         rng: &mut R,
         tree_depth: u8,
-        input_amount: AmountValue,
-        fee: AmountValue,
-        mint_amount: AmountValue,
+        input_amount: Amount,
+        fee: Amount,
+        mint_amount: Amount,
         issuer_keypair: &'a UserKeyPair,
         receiver_keypair: &'a UserKeyPair,
         auditor_keypair: &'a AuditorKeyPair,
@@ -999,7 +999,7 @@ impl<'a> MintParamsBuilder<'a> {
         let fee_chg = if self.fee_ro.amount >= self.fee {
             self.fee_ro.amount - self.fee
         } else {
-            AmountValue(u128::MAX) // to cause error later on
+            Amount(u128::MAX) // to cause error later on
         };
         let chg_ro = RecordOpening::new(
             rng,
@@ -1097,9 +1097,9 @@ impl<'a> MintParamsBuilder<'a> {
     where
         R: RngCore + CryptoRng,
     {
-        let input_amount = AmountValue(rng.gen_range(1..50));
-        let fee = AmountValue(rng.gen_range(1..=input_amount.0));
-        let mint_amount = AmountValue(rng.gen_range(1..100));
+        let input_amount = Amount(rng.gen_range(1..50));
+        let fee = Amount(rng.gen_range(1..=input_amount.0));
+        let mint_amount = Amount(rng.gen_range(1..100));
         Self::new(
             rng,
             tree_depth,
@@ -1119,16 +1119,16 @@ pub struct FreezeParamsBuilder<'a> {
     tree_depth: u8,
     pub(crate) inputs: Vec<FreezeNoteInput<'a>>,
     pub(crate) fee_input: FeeInput<'a>,
-    pub(crate) fee: AmountValue,
+    pub(crate) fee: Amount,
 }
 
 impl<'a> FreezeParamsBuilder<'a> {
     /// Instantiate a new FreezeParamsBuilder
     pub fn new(
         tree_depth: u8,
-        input_amounts: &[AmountValue],
-        fee_input_amount: AmountValue,
-        fee: AmountValue,
+        input_amounts: &[Amount],
+        fee_input_amount: Amount,
+        fee: Amount,
         fee_keypair: &'a UserKeyPair,
         freezing_keypairs: Vec<&'a FreezerKeyPair>,
     ) -> Self {
@@ -1201,10 +1201,10 @@ impl<'a> FreezeParamsBuilder<'a> {
         assert!(num_input > 0, "require at least one input for freezing");
         let mut input_amounts = vec![];
         for _ in 0..num_input {
-            input_amounts.push(AmountValue(rng.gen_range(1..50)));
+            input_amounts.push(Amount(rng.gen_range(1..50)));
         }
-        let fee_input_amount = AmountValue(rng.gen_range(1..10));
-        let fee = AmountValue(rng.gen_range(1..=fee_input_amount.0));
+        let fee_input_amount = Amount(rng.gen_range(1..10));
+        let fee = Amount(rng.gen_range(1..=fee_input_amount.0));
         let builder = Self::new(
             tree_depth,
             &input_amounts,
@@ -1274,7 +1274,7 @@ impl<'a> FreezeParamsBuilder<'a> {
         self
     }
 
-    pub(crate) fn update_fee_input_amount(mut self, fee_amount: AmountValue) -> Self {
+    pub(crate) fn update_fee_input_amount(mut self, fee_amount: Amount) -> Self {
         self.fee_input.ro.amount = fee_amount;
         self.refresh_merkle_root();
         self
@@ -1391,7 +1391,7 @@ impl AssetPolicy {
             cred_pk: CredIssuerKeyPair::generate(rng).pub_key(),
             freezer_pk: FreezerKeyPair::generate(rng).pub_key(),
             reveal_map: RevealMap::rand_for_test(rng),
-            reveal_threshold: AmountValue(rng.next_u64() as u128),
+            reveal_threshold: Amount(rng.next_u64() as u128),
         }
     }
 }
@@ -1399,7 +1399,7 @@ impl AssetPolicy {
 impl RecordOpening {
     /// Create a random record opening. Only used for testing.
     pub fn rand_for_test<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        let amount = AmountValue(rng.next_u64() as u128); // In order to avoid possible u128 overflows
+        let amount = Amount(rng.next_u64() as u128); // In order to avoid possible u128 overflows
         let asset_def = AssetDefinition::rand_for_test(rng);
         let pub_key = UserKeyPair::generate(rng).pub_key();
         let freeze_flag = FreezeFlag::Unfrozen;

--- a/src/utils/params_builder.rs
+++ b/src/utils/params_builder.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     sign_receiver_memos,
     structs::{
-        AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AssetPolicy,
+        AmountValue, AssetCode, AssetCodeDigest, AssetCodeSeed, AssetDefinition, AssetPolicy,
         ExpirableCredential, FeeInput, FreezeFlag, IdentityAttribute, NoteType, ReceiverMemo,
         RecordOpening, RevealMap, TxnFeeInfo,
     },
@@ -432,7 +432,7 @@ impl<'a> TransferParamsBuilder<'a> {
         self.refresh_merkle_root()
     }
 
-    pub(crate) fn set_reveal_threshold(mut self, reveal_threshold: u64) -> Self {
+    pub(crate) fn set_reveal_threshold(mut self, reveal_threshold: AmountValue) -> Self {
         assert!(
             self.transfer_asset_def.is_some(),
             "reveal_threshold cannot be set on native asset"
@@ -478,7 +478,7 @@ impl<'a> TransferParamsBuilder<'a> {
     ///   overall left over amount
     /// * `amounts` - list of input amounts (the first amount corresponds to the
     ///   native asset)
-    pub fn set_input_amounts(mut self, fee_input: u64, amounts: &[u64]) -> Self {
+    pub fn set_input_amounts(mut self, fee_input: AmountValue, amounts: &[AmountValue]) -> Self {
         assert!(self.input_ros.is_empty(), "Input records already set");
         assert_eq!(
             amounts.len() + 1,
@@ -521,7 +521,7 @@ impl<'a> TransferParamsBuilder<'a> {
     /// Define the outputs amounts of a Transfer note
     /// * `amounts` - list of input amounts (the first amount corresponds to the
     ///   native asset)
-    pub fn set_output_amounts(mut self, fee_chg: u64, amounts: &[u64]) -> Self {
+    pub fn set_output_amounts(mut self, fee_chg: AmountValue, amounts: &[AmountValue]) -> Self {
         assert!(self.output_ros.is_empty(), "Output records already set");
         assert_eq!(
             amounts.len() + 1,
@@ -646,7 +646,7 @@ impl<'a> TransferParamsBuilder<'a> {
     pub(crate) fn set_dummy_input_record(mut self, index: usize) -> Self {
         assert!(index < self.input_ros.len());
         self.input_ros[index + 1].asset_def = AssetDefinition::dummy(); // first position is reserved for input fee
-        self.input_ros[index + 1].amount = 0;
+        self.input_ros[index + 1].amount = AmountValue(0);
         // self.input_ros[index + 1].pub_key.address = Default::default();
         self.refresh_merkle_root()
     }
@@ -666,12 +666,12 @@ impl<'a> TransferParamsBuilder<'a> {
         self
     }
 
-    pub(crate) fn update_fee_input_amount(mut self, amount: u64) -> Self {
+    pub(crate) fn update_fee_input_amount(mut self, amount: AmountValue) -> Self {
         self.input_ros[0].amount = amount;
         self.refresh_merkle_root()
     }
 
-    pub(crate) fn update_input_amount(mut self, index: usize, amount: u64) -> Self {
+    pub(crate) fn update_input_amount(mut self, index: usize, amount: AmountValue) -> Self {
         assert!(index < self.input_ros.len());
         self.input_ros[index + 1].amount = amount;
         self.refresh_merkle_root()
@@ -695,12 +695,13 @@ impl<'a> TransferParamsBuilder<'a> {
         let cred_expiry = rng.gen_range(valid_until + 1..2000);
         // guarantee: fee change < fee, the rest reserve balances
         let (fee_input, input_amounts, fee_chg, output_amounts) = {
-            let fee: u64 = rng.gen_range(1..20);
-            let fee_change = rng.gen_range(1..=fee);
-            let transfer_amount =
-                rng.gen_range(1..50) * (num_input as u64 - 1) * (num_output as u64 - 1);
-            let input_amounts = vec![transfer_amount / (num_input as u64 - 1); num_input - 1];
-            let output_amounts = vec![transfer_amount / (num_output as u64 - 1); num_output - 1];
+            let fee = AmountValue(rng.gen_range(1..20));
+            let fee_change = AmountValue(rng.gen_range(1..=fee.0));
+            let transfer_amount = AmountValue(
+                rng.gen_range(1..50) * (num_input as u128 - 1) * (num_output as u128 - 1) as u128,
+            );
+            let input_amounts = vec![transfer_amount / (num_input as u128 - 1); num_input - 1];
+            let output_amounts = vec![transfer_amount / (num_output as u128 - 1); num_output - 1];
             (fee, input_amounts, fee_change, output_amounts)
         };
 
@@ -904,7 +905,7 @@ pub struct MintParamsBuilder<'a> {
     tree_depth: u8,
     pub(crate) issuer_keypair: &'a UserKeyPair,
     pub(crate) fee_ro: RecordOpening,
-    pub(crate) fee: u64,
+    pub(crate) fee: AmountValue,
     pub(crate) mint_ro: RecordOpening,
     pub(crate) ac_seed: AssetCodeSeed,
     pub(crate) ac_description: Vec<u8>,
@@ -920,9 +921,9 @@ impl<'a> MintParamsBuilder<'a> {
     pub fn new<R>(
         rng: &mut R,
         tree_depth: u8,
-        input_amount: u64,
-        fee: u64,
-        mint_amount: u64,
+        input_amount: AmountValue,
+        fee: AmountValue,
+        mint_amount: AmountValue,
         issuer_keypair: &'a UserKeyPair,
         receiver_keypair: &'a UserKeyPair,
         auditor_keypair: &'a AuditorKeyPair,
@@ -998,7 +999,7 @@ impl<'a> MintParamsBuilder<'a> {
         let fee_chg = if self.fee_ro.amount >= self.fee {
             self.fee_ro.amount - self.fee
         } else {
-            u64::MAX // to cause error later on
+            AmountValue(u128::MAX) // to cause error later on
         };
         let chg_ro = RecordOpening::new(
             rng,
@@ -1096,9 +1097,9 @@ impl<'a> MintParamsBuilder<'a> {
     where
         R: RngCore + CryptoRng,
     {
-        let input_amount: u64 = rng.gen_range(1..50);
-        let fee = rng.gen_range(1..=input_amount);
-        let mint_amount: u64 = rng.gen_range(1..100);
+        let input_amount = AmountValue(rng.gen_range(1..50));
+        let fee = AmountValue(rng.gen_range(1..=input_amount.0));
+        let mint_amount = AmountValue(rng.gen_range(1..100));
         Self::new(
             rng,
             tree_depth,
@@ -1118,16 +1119,16 @@ pub struct FreezeParamsBuilder<'a> {
     tree_depth: u8,
     pub(crate) inputs: Vec<FreezeNoteInput<'a>>,
     pub(crate) fee_input: FeeInput<'a>,
-    pub(crate) fee: u64,
+    pub(crate) fee: AmountValue,
 }
 
 impl<'a> FreezeParamsBuilder<'a> {
     /// Instantiate a new FreezeParamsBuilder
     pub fn new(
         tree_depth: u8,
-        input_amounts: &[u64],
-        fee_input_amount: u64,
-        fee: u64,
+        input_amounts: &[AmountValue],
+        fee_input_amount: AmountValue,
+        fee: AmountValue,
         fee_keypair: &'a UserKeyPair,
         freezing_keypairs: Vec<&'a FreezerKeyPair>,
     ) -> Self {
@@ -1200,10 +1201,10 @@ impl<'a> FreezeParamsBuilder<'a> {
         assert!(num_input > 0, "require at least one input for freezing");
         let mut input_amounts = vec![];
         for _ in 0..num_input {
-            input_amounts.push(rng.gen_range(1..50));
+            input_amounts.push(AmountValue(rng.gen_range(1..50)));
         }
-        let fee_input_amount = rng.gen_range(1..10);
-        let fee = rng.gen_range(1..=fee_input_amount);
+        let fee_input_amount = AmountValue(rng.gen_range(1..10));
+        let fee = AmountValue(rng.gen_range(1..=fee_input_amount.0));
         let builder = Self::new(
             tree_depth,
             &input_amounts,
@@ -1273,7 +1274,7 @@ impl<'a> FreezeParamsBuilder<'a> {
         self
     }
 
-    pub(crate) fn update_fee_input_amount(mut self, fee_amount: u64) -> Self {
+    pub(crate) fn update_fee_input_amount(mut self, fee_amount: AmountValue) -> Self {
         self.fee_input.ro.amount = fee_amount;
         self.refresh_merkle_root();
         self
@@ -1390,7 +1391,7 @@ impl AssetPolicy {
             cred_pk: CredIssuerKeyPair::generate(rng).pub_key(),
             freezer_pk: FreezerKeyPair::generate(rng).pub_key(),
             reveal_map: RevealMap::rand_for_test(rng),
-            reveal_threshold: rng.next_u32() as u64,
+            reveal_threshold: AmountValue(rng.next_u64() as u128),
         }
     }
 }
@@ -1398,7 +1399,7 @@ impl AssetPolicy {
 impl RecordOpening {
     /// Create a random record opening. Only used for testing.
     pub fn rand_for_test<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        let amount = rng.next_u32() as u64; // In order to avoid possible u64 overflows
+        let amount = AmountValue(rng.next_u64() as u128); // In order to avoid possible u128 overflows
         let asset_def = AssetDefinition::rand_for_test(rng);
         let pub_key = UserKeyPair::generate(rng).pub_key();
         let freeze_flag = FreezeFlag::Unfrozen;

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -38,9 +38,9 @@ use jf_cap::{
     },
     sign_receiver_memos,
     structs::{
-        AssetCode, AssetCodeSeed, AssetDefinition, AssetPolicy, AuditData, BlindFactor,
-        ExpirableCredential, FeeInput, FreezeFlag, IdentityAttribute, Nullifier, ReceiverMemo,
-        RecordCommitment, RecordOpening, TxnFeeInfo,
+        AmountValue, AssetCode, AssetCodeSeed, AssetDefinition, AssetPolicy, AuditData,
+        BlindFactor, ExpirableCredential, FeeInput, FreezeFlag, IdentityAttribute, Nullifier,
+        ReceiverMemo, RecordCommitment, RecordOpening, TxnFeeInfo,
     },
     transfer::{TransferNote, TransferNoteInput},
     txn_batch_verify, BaseField, CurveParam, TransactionNote, TransactionVerifyingKey,
@@ -89,7 +89,7 @@ impl LedgerStateMock {
         &mut self,
         rng: &mut R,
         owner_pub_key: UserPubKey,
-        amount: u64,
+        amount: AmountValue,
     ) -> (RecordOpening, u64) {
         let ro = RecordOpening::new(
             rng,
@@ -110,7 +110,7 @@ impl LedgerStateMock {
         &mut self,
         rng: &mut R,
         owner_pub_key: UserPubKey,
-        amount: u64,
+        amount: AmountValue,
         asset_definition: AssetDefinition,
     ) -> (RecordOpening, u64) {
         let ro = RecordOpening::new(
@@ -799,7 +799,7 @@ impl<'a> FreezerMock<'a> {
         &mut self,
         rng: &mut R,
         user: &UserAddress,
-        fee: u64,
+        fee: AmountValue,
         merkle_tree_oracle: &MerkleTree<BaseField>,
     ) -> Result<(FreezeNote, Vec<ReceiverMemo>, Signature<CurveParam>)> {
         self.freeze_user_internal(rng, user, fee, merkle_tree_oracle, false)
@@ -810,7 +810,7 @@ impl<'a> FreezerMock<'a> {
         &mut self,
         rng: &mut R,
         user: &UserAddress,
-        fee: u64,
+        fee: AmountValue,
         merkle_tree_oracle: &MerkleTree<BaseField>,
     ) -> Result<(FreezeNote, Vec<ReceiverMemo>, Signature<CurveParam>)> {
         self.freeze_user_internal(rng, user, fee, merkle_tree_oracle, true)
@@ -821,7 +821,7 @@ impl<'a> FreezerMock<'a> {
         &mut self,
         rng: &mut R,
         user: &UserAddress,
-        fee: u64,
+        fee: AmountValue,
         merkle_tree_oracle: &MerkleTree<BaseField>,
         freeze: bool, // true: freeze, false: unfreeze
     ) -> Result<(FreezeNote, Vec<ReceiverMemo>, Signature<CurveParam>)> {
@@ -1002,10 +1002,10 @@ impl<'a> SimpleUserWalletMock<'a> {
     }
 
     /// computes spendable funds for given asset code
-    pub fn available_funds(&self, asset_code: &AssetCode) -> u64 {
+    pub fn available_funds(&self, asset_code: &AssetCode) -> AmountValue {
         match self.unspent_records.get(asset_code) {
             Some(records) => records.iter().map(|(record, _uid)| record.amount).sum(),
-            None => 0u64,
+            None => 0u128.into(),
         }
     }
 
@@ -1142,7 +1142,7 @@ impl<'a> SimpleUserWalletMock<'a> {
 
     /// find a record and corresponding uid on the native asset type with enough
     /// funds to pay transaction fee
-    fn find_record_for_fee(&self, fee: u64) -> Result<(RecordOpening, u64)> {
+    fn find_record_for_fee(&self, fee: AmountValue) -> Result<(RecordOpening, u64)> {
         let unspent_native_assets = self
             .unspent_records
             .get(&AssetDefinition::native().code)
@@ -1164,10 +1164,10 @@ impl<'a> SimpleUserWalletMock<'a> {
     fn find_records(
         &self,
         asset_code: &AssetCode,
-        amount: u64,
-    ) -> Result<(Vec<(RecordOpening, u64)>, u64)> {
+        amount: AmountValue,
+    ) -> Result<(Vec<(RecordOpening, u64)>, AmountValue)> {
         let mut result = vec![];
-        let mut current_amount = 0u64;
+        let mut current_amount: AmountValue = 0u128.into();
         let unspent_records = self
             .unspent_records
             .get(asset_code)
@@ -1193,13 +1193,13 @@ impl<'a> SimpleUserWalletMock<'a> {
     pub fn spend_native<R: CryptoRng + RngCore>(
         &mut self,
         rng: &mut R,
-        output_addresses_and_amounts: &[(UserPubKey, u64)],
-        fee: u64,
+        output_addresses_and_amounts: &[(UserPubKey, AmountValue)],
+        fee: AmountValue,
         merkle_tree_oracle: &MerkleTree<BaseField>,
     ) -> Result<(TransferNote, Vec<ReceiverMemo>, Signature<CurveParam>)> {
-        let total_output_amount: u64 = output_addresses_and_amounts
+        let total_output_amount: AmountValue = output_addresses_and_amounts
             .iter()
-            .fold(0, |acc, (_, amount)| acc + amount)
+            .fold(0.into(), |acc: AmountValue, (_, amount)| acc + *amount)
             + fee;
 
         // find input records of the asset type to spent
@@ -1301,8 +1301,8 @@ impl<'a> SimpleUserWalletMock<'a> {
         &mut self,
         rng: &mut R,
         asset_def: &AssetDefinition,
-        output_addresses_and_amounts: &[(UserPubKey, u64)],
-        fee: u64,
+        output_addresses_and_amounts: &[(UserPubKey, AmountValue)],
+        fee: AmountValue,
         merkle_tree_oracle: &MerkleTree<BaseField>,
     ) -> Result<(TransferNote, Vec<ReceiverMemo>, Signature<CurveParam>)> {
         assert_ne!(
@@ -1310,9 +1310,9 @@ impl<'a> SimpleUserWalletMock<'a> {
             AssetDefinition::native(),
             "call `spend_native()` instead"
         );
-        let total_output_amount: u64 = output_addresses_and_amounts
+        let total_output_amount: AmountValue = output_addresses_and_amounts
             .iter()
-            .fold(0, |acc, (_, amount)| acc + amount);
+            .fold(0.into(), |acc, (_, amount)| acc + *amount);
 
         let (fee_ro, fee_uid) = self.find_record_for_fee(fee)?;
         {
@@ -1386,7 +1386,7 @@ impl<'a> SimpleUserWalletMock<'a> {
             ));
         }
         // change in the asset type being transfered (not fee change)
-        if change > 0 {
+        if change > 0.into() {
             let change_ro = RecordOpening::new(
                 rng,
                 change,
@@ -1538,9 +1538,9 @@ impl<'a> AssetIssuerMock<'a> {
     pub fn mint<R: CryptoRng + RngCore>(
         &mut self,
         rng: &mut R,
-        fee: u64,
+        fee: AmountValue,
         asset_code: &AssetCode,
-        amount: u64,
+        amount: AmountValue,
         owner: UserPubKey,
         merkle_tree_oracle: &MerkleTree<BaseField>,
     ) -> Result<(
@@ -1628,7 +1628,7 @@ pub fn example_native_asset_transfer() {
     let mut receiver_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let receiver_pub_key = receiver_wallet.pub_key();
 
-    let mint_amount = 10;
+    let mint_amount = 10.into();
     let (record_opening_in, uid) =
         ledger_state.mock_mint_native_asset(rng, sender_pub_key.clone(), mint_amount);
     sender_wallet.add_record_opening(record_opening_in, uid);
@@ -1637,8 +1637,8 @@ pub fn example_native_asset_transfer() {
         mint_amount
     );
 
-    let fee = 1;
-    let change_back = 2;
+    let fee = 1.into();
+    let change_back = 2.into();
     let (xfr_note, recv_memos, recv_memos_sig) = sender_wallet
         .spend_native(
             rng,
@@ -1686,7 +1686,7 @@ pub fn example_native_asset_transfer() {
     let (xfr_note2, recv_memos2, _recv_memos_sig2) = receiver_wallet
         .spend_native(
             rng,
-            &[(sender_pub_key, mint_amount - 2 * fee - change_back)],
+            &[(sender_pub_key, mint_amount - fee - fee - change_back)],
             fee,
             &ledger_state.mt,
         )
@@ -1703,10 +1703,13 @@ pub fn example_native_asset_transfer() {
     sender_wallet.scan_txn(&txn2, &recv_memos2, uid_offset);
     assert_eq!(
         sender_wallet.available_funds(&AssetCode::native()),
-        mint_amount - 2 * fee
+        mint_amount - fee - fee
     );
     receiver_wallet.scan_txn(&txn2, &recv_memos2, uid_offset);
-    assert_eq!(receiver_wallet.available_funds(&AssetCode::native()), 0);
+    assert_eq!(
+        receiver_wallet.available_funds(&AssetCode::native()),
+        0.into()
+    );
 }
 
 /// This tests shows how to generate and verify transfer notes transferring non
@@ -1733,8 +1736,8 @@ pub fn example_non_native_asset_transfer() {
     let mut receiver_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let recv_pub_key = receiver_wallet.pub_key();
     assert_ne!(recv_pub_key, sender_wallet.pub_key());
-    let native_amount = 10;
-    let non_native_amount = 15;
+    let native_amount = 10.into();
+    let non_native_amount = 15.into();
 
     let (asset_code, ..) = AssetCode::random(rng);
     let policy = AssetPolicy::default();
@@ -1752,7 +1755,7 @@ pub fn example_non_native_asset_transfer() {
     );
     sender_wallet.add_record_opening(record_opening_in, uid);
 
-    let fee = 2;
+    let fee = 2.into();
     let (xfr_note, recv_memos, recv_memos_sig) = sender_wallet
         .spend_non_native(
             rng,
@@ -1822,8 +1825,8 @@ pub fn example_test_traced_asset_transfer() {
     let mut sender_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let mut receiver_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let recv_pub_key = receiver_wallet.pub_key();
-    let native_amount = 10;
-    let non_native_amount = 15;
+    let native_amount = 10.into();
+    let non_native_amount = 15.into();
 
     let auditor_keypair = AuditorKeyPair::generate(rng);
     let policy = AssetPolicy::default()
@@ -1846,7 +1849,7 @@ pub fn example_test_traced_asset_transfer() {
     );
     sender_wallet.add_record_opening(record_opening_in.clone(), uid);
 
-    let fee = 2;
+    let fee = 2.into();
     let (xfr_note, recv_memos, recv_memos_sig) = sender_wallet
         .spend_non_native(
             rng,
@@ -1935,8 +1938,8 @@ pub fn example_traced_non_native_asset_with_credentials() {
     let mut sender_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let mut receiver_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let recv_pub_key = receiver_wallet.pub_key();
-    let native_amount = 10;
-    let non_native_amount = 15;
+    let native_amount = 10.into();
+    let non_native_amount = 15.into();
 
     let auditor_keypair = AuditorKeyPair::generate(rng);
     let cred_issuer_keypair = CredIssuerKeyPair::generate(rng);
@@ -1984,7 +1987,7 @@ pub fn example_traced_non_native_asset_with_credentials() {
     );
     sender_wallet.add_record_opening(record_opening_in.clone(), uid);
 
-    let fee = 2;
+    let fee = 2.into();
     let (xfr_note, recv_memos, recv_memos_sig) = sender_wallet
         .spend_non_native(
             rng,
@@ -2049,7 +2052,7 @@ fn check_transfer_audit_data(
     data: &AuditData,
     expected_code: AssetCode,
     expected_user_address: Option<UserAddress>,
-    expected_amount: Option<u64>,
+    expected_amount: Option<AmountValue>,
     expected_blind_factor: Option<BlindFactor>,
     expected_attributes: Vec<Option<IdentityAttribute>>,
 ) {
@@ -2069,7 +2072,7 @@ fn example_fee_collection_and_batch_verification() {
 
     // setting up wallets
     let mut senders_wallets = vec![];
-    let amounts = [10u64, 20, 30, 40];
+    let amounts = AmountValue::from_vec(&[10, 20, 30, 40]);
     for _ in amounts.iter() {
         let user_wallet = SimpleUserWalletMock::generate(rng, &srs);
         senders_wallets.push(user_wallet);
@@ -2085,7 +2088,7 @@ fn example_fee_collection_and_batch_verification() {
 
     // generate set of xfr_notes
     let mut xfr_notes = vec![];
-    let fee = 1;
+    let fee = AmountValue::from(1u128);
     for (wallet, amount) in senders_wallets.iter_mut().zip(amounts.iter()) {
         let (xfr_note, _recv_memos, _recv_memos_sig) = wallet
             .spend_native(
@@ -2133,7 +2136,7 @@ fn example_fee_collection_and_batch_verification() {
     );
     assert_eq!(
         block_proposer.wallet.available_funds(&AssetCode::native()),
-        fee * (amounts.len() as u64)
+        fee * (amounts.len() as u128)
     );
 }
 
@@ -2150,16 +2153,16 @@ fn example_mint() {
     let owner_pub_key = owner_wallet.pub_key();
     // initialize the wallet with some native asset to be used to pay txn fee
     {
-        let amount = 10;
+        let amount = 10.into();
         let (init_balance_ro, uid) =
             ledger_state.mock_mint_native_asset(rng, asset_issuer.wallet.pub_key(), amount);
         asset_issuer.wallet.add_record_opening(init_balance_ro, uid);
     }
 
     // issue/mint a new asset
-    let mint_amount: u64 = 1000000;
+    let mint_amount = 1000000.into();
     let asset_code = asset_issuer.new_asset_definition(rng, b"BankX USD", AssetPolicy::default());
-    let fee = 1;
+    let fee = 1.into();
     let (mint_note, _sig, fee_chg_recv_memo) = asset_issuer
         .mint(
             rng,
@@ -2220,8 +2223,8 @@ fn example_freeze() {
     // setting up wallets
     let mut user1 = SimpleUserWalletMock::generate(rng, &srs); // sender
     let mut user2 = SimpleUserWalletMock::generate(rng, &srs); // receiver
-    let native_amount = 10;
-    let non_native_amount = 5;
+    let native_amount = 10.into();
+    let non_native_amount = 5.into();
 
     // set up freezer
     let (asset_code, _) = AssetCode::random(rng);
@@ -2256,7 +2259,7 @@ fn example_freeze() {
     let mut uid_offset = ledger_state.next_uid();
 
     // user1  transfer freezable asset to user2
-    let fee = 1;
+    let fee = 1.into();
     let (xfr, recv_memos, _sig) = user1
         .spend_non_native(
             rng,
@@ -2297,13 +2300,18 @@ fn example_freeze() {
         .unwrap();
     check_freezer_status(&freezer, native_amount, &user2, 1, 0, 0, 0);
     // user2's funds available after scanning block
-    assert_eq!(user2.available_funds(&asset_code), 0);
+    assert_eq!(user2.available_funds(&asset_code), 0.into());
     user2.scan_block(&block, &[&recv_memos], prev_uid_offset);
     assert_eq!(user2.available_funds(&asset_code), non_native_amount);
 
     // freezer freezes user2 freezable records
     let (freeze_note, recv_memos, _sig) = freezer
-        .freeze_user(rng, &user2.pub_key().address(), fee, &ledger_state.mt)
+        .freeze_user(
+            rng,
+            &user2.pub_key().address(),
+            fee.into(),
+            &ledger_state.mt,
+        )
         .unwrap();
 
     check_freezer_status(&freezer, native_amount, &user2, 1, 0, 1, 0);
@@ -2333,17 +2341,17 @@ fn example_freeze() {
         .scan_block(&block, &[&recv_memos], prev_uid_offset)
         .unwrap();
 
-    check_freezer_status(&freezer, native_amount - fee, &user2, 0, 1, 0, 0);
+    check_freezer_status(&freezer, (native_amount - fee).into(), &user2, 0, 1, 0, 0);
 
     // user2's funds unavailable after scanning block
     user2.scan_block(&block, &[&recv_memos], prev_uid_offset);
-    assert_eq!(user2.available_funds(&asset_code), 0);
+    assert_eq!(user2.available_funds(&asset_code), 0.into());
 
     let (unfreeze_note, freeze_recv_memos, _sig) = freezer
-        .unfreeze_user(rng, &user2.pub_key().address(), 1, &ledger_state.mt)
+        .unfreeze_user(rng, &user2.pub_key().address(), 1.into(), &ledger_state.mt)
         .unwrap();
 
-    check_freezer_status(&freezer, native_amount - fee, &user2, 0, 1, 0, 1);
+    check_freezer_status(&freezer, (native_amount - fee).into(), &user2, 0, 1, 0, 1);
 
     // add a minting note with another freezable record
     let mut issuer = AssetIssuerMock::new(rng, &srs);
@@ -2356,11 +2364,11 @@ fn example_freeze() {
     let (record, uid) =
         ledger_state.mock_mint_native_asset(rng, issuer.wallet.pub_key(), native_amount);
     issuer.wallet.add_record_opening(record, uid);
-    let new_asset_amount = 20u64;
+    let new_asset_amount = 20u128.into();
     let (mint_note, _sig, fee_ch_recv_memo) = issuer
         .mint(
             rng,
-            fee,
+            fee.into(),
             &new_asset_code,
             new_asset_amount,
             user1.pub_key(),
@@ -2398,8 +2406,8 @@ fn example_freeze() {
         )
         .unwrap();
 
-    check_freezer_status(&freezer, native_amount - 2 * fee, &user2, 1, 0, 0, 0);
-    check_freezer_status(&freezer, native_amount - 2 * fee, &user1, 1, 0, 0, 0);
+    check_freezer_status(&freezer, native_amount - fee - fee, &user2, 1, 0, 0, 0);
+    check_freezer_status(&freezer, native_amount - fee - fee, &user1, 1, 0, 0, 0);
     // check user 2 funds available again
     user2.scan_block(
         &block,
@@ -2408,7 +2416,7 @@ fn example_freeze() {
     );
     assert_eq!(user2.available_funds(&asset_code), non_native_amount);
 
-    assert_eq!(user1.available_funds(&new_asset_code), 0);
+    assert_eq!(user1.available_funds(&new_asset_code), 0.into());
     user1.scan_block(
         &block,
         &[&freeze_recv_memos, &mint_recv_memos],
@@ -2419,7 +2427,7 @@ fn example_freeze() {
 
 fn check_freezer_status(
     freezer: &FreezerMock,
-    available_native_funds: u64,
+    available_native_funds: AmountValue,
     user: &SimpleUserWalletMock,
     user_freezable_records: usize,
     user_releasable_records: usize,

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1199,7 +1199,7 @@ impl<'a> SimpleUserWalletMock<'a> {
     ) -> Result<(TransferNote, Vec<ReceiverMemo>, Signature<CurveParam>)> {
         let total_output_amount: Amount = output_addresses_and_amounts
             .iter()
-            .fold(0.into(), |acc: Amount, (_, amount)| acc + *amount)
+            .fold(0u64.into(), |acc: Amount, (_, amount)| acc + *amount)
             + fee;
 
         // find input records of the asset type to spent
@@ -1312,7 +1312,7 @@ impl<'a> SimpleUserWalletMock<'a> {
         );
         let total_output_amount: Amount = output_addresses_and_amounts
             .iter()
-            .fold(0.into(), |acc, (_, amount)| acc + *amount);
+            .fold(0u64.into(), |acc, (_, amount)| acc + *amount);
 
         let (fee_ro, fee_uid) = self.find_record_for_fee(fee)?;
         {
@@ -1386,7 +1386,7 @@ impl<'a> SimpleUserWalletMock<'a> {
             ));
         }
         // change in the asset type being transfered (not fee change)
-        if change > 0.into() {
+        if change > 0u64.into() {
             let change_ro = RecordOpening::new(
                 rng,
                 change,
@@ -1628,7 +1628,7 @@ pub fn example_native_asset_transfer() {
     let mut receiver_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let receiver_pub_key = receiver_wallet.pub_key();
 
-    let mint_amount = 10.into();
+    let mint_amount = 10u64.into();
     let (record_opening_in, uid) =
         ledger_state.mock_mint_native_asset(rng, sender_pub_key.clone(), mint_amount);
     sender_wallet.add_record_opening(record_opening_in, uid);
@@ -1637,8 +1637,8 @@ pub fn example_native_asset_transfer() {
         mint_amount
     );
 
-    let fee = 1.into();
-    let change_back = 2.into();
+    let fee = 1u64.into();
+    let change_back = 2u64.into();
     let (xfr_note, recv_memos, recv_memos_sig) = sender_wallet
         .spend_native(
             rng,
@@ -1708,7 +1708,7 @@ pub fn example_native_asset_transfer() {
     receiver_wallet.scan_txn(&txn2, &recv_memos2, uid_offset);
     assert_eq!(
         receiver_wallet.available_funds(&AssetCode::native()),
-        0.into()
+        0u64.into()
     );
 }
 
@@ -1736,8 +1736,8 @@ pub fn example_non_native_asset_transfer() {
     let mut receiver_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let recv_pub_key = receiver_wallet.pub_key();
     assert_ne!(recv_pub_key, sender_wallet.pub_key());
-    let native_amount = 10.into();
-    let non_native_amount = 15.into();
+    let native_amount = 10u64.into();
+    let non_native_amount = 15u64.into();
 
     let (asset_code, ..) = AssetCode::random(rng);
     let policy = AssetPolicy::default();
@@ -1755,7 +1755,7 @@ pub fn example_non_native_asset_transfer() {
     );
     sender_wallet.add_record_opening(record_opening_in, uid);
 
-    let fee = 2.into();
+    let fee = 2u64.into();
     let (xfr_note, recv_memos, recv_memos_sig) = sender_wallet
         .spend_non_native(
             rng,
@@ -1825,8 +1825,8 @@ pub fn example_test_traced_asset_transfer() {
     let mut sender_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let mut receiver_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let recv_pub_key = receiver_wallet.pub_key();
-    let native_amount = 10.into();
-    let non_native_amount = 15.into();
+    let native_amount = 10u64.into();
+    let non_native_amount = 15u64.into();
 
     let auditor_keypair = AuditorKeyPair::generate(rng);
     let policy = AssetPolicy::default()
@@ -1849,7 +1849,7 @@ pub fn example_test_traced_asset_transfer() {
     );
     sender_wallet.add_record_opening(record_opening_in.clone(), uid);
 
-    let fee = 2.into();
+    let fee = 2u64.into();
     let (xfr_note, recv_memos, recv_memos_sig) = sender_wallet
         .spend_non_native(
             rng,
@@ -1938,8 +1938,8 @@ pub fn example_traced_non_native_asset_with_credentials() {
     let mut sender_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let mut receiver_wallet = SimpleUserWalletMock::generate(rng, &srs);
     let recv_pub_key = receiver_wallet.pub_key();
-    let native_amount = 10.into();
-    let non_native_amount = 15.into();
+    let native_amount = 10u64.into();
+    let non_native_amount = 15u64.into();
 
     let auditor_keypair = AuditorKeyPair::generate(rng);
     let cred_issuer_keypair = CredIssuerKeyPair::generate(rng);
@@ -1987,7 +1987,7 @@ pub fn example_traced_non_native_asset_with_credentials() {
     );
     sender_wallet.add_record_opening(record_opening_in.clone(), uid);
 
-    let fee = 2.into();
+    let fee = 2u64.into();
     let (xfr_note, recv_memos, recv_memos_sig) = sender_wallet
         .spend_non_native(
             rng,
@@ -2153,16 +2153,16 @@ fn example_mint() {
     let owner_pub_key = owner_wallet.pub_key();
     // initialize the wallet with some native asset to be used to pay txn fee
     {
-        let amount = 10.into();
+        let amount = 10u64.into();
         let (init_balance_ro, uid) =
             ledger_state.mock_mint_native_asset(rng, asset_issuer.wallet.pub_key(), amount);
         asset_issuer.wallet.add_record_opening(init_balance_ro, uid);
     }
 
     // issue/mint a new asset
-    let mint_amount = 1000000.into();
+    let mint_amount = 1000000u64.into();
     let asset_code = asset_issuer.new_asset_definition(rng, b"BankX USD", AssetPolicy::default());
-    let fee = 1.into();
+    let fee = 1u64.into();
     let (mint_note, _sig, fee_chg_recv_memo) = asset_issuer
         .mint(
             rng,
@@ -2223,8 +2223,8 @@ fn example_freeze() {
     // setting up wallets
     let mut user1 = SimpleUserWalletMock::generate(rng, &srs); // sender
     let mut user2 = SimpleUserWalletMock::generate(rng, &srs); // receiver
-    let native_amount = 10.into();
-    let non_native_amount = 5.into();
+    let native_amount = 10u64.into();
+    let non_native_amount = 5u64.into();
 
     // set up freezer
     let (asset_code, _) = AssetCode::random(rng);
@@ -2259,7 +2259,7 @@ fn example_freeze() {
     let mut uid_offset = ledger_state.next_uid();
 
     // user1  transfer freezable asset to user2
-    let fee = 1.into();
+    let fee = 1u64.into();
     let (xfr, recv_memos, _sig) = user1
         .spend_non_native(
             rng,
@@ -2300,7 +2300,7 @@ fn example_freeze() {
         .unwrap();
     check_freezer_status(&freezer, native_amount, &user2, 1, 0, 0, 0);
     // user2's funds available after scanning block
-    assert_eq!(user2.available_funds(&asset_code), 0.into());
+    assert_eq!(user2.available_funds(&asset_code), 0u64.into());
     user2.scan_block(&block, &[&recv_memos], prev_uid_offset);
     assert_eq!(user2.available_funds(&asset_code), non_native_amount);
 
@@ -2345,10 +2345,15 @@ fn example_freeze() {
 
     // user2's funds unavailable after scanning block
     user2.scan_block(&block, &[&recv_memos], prev_uid_offset);
-    assert_eq!(user2.available_funds(&asset_code), 0.into());
+    assert_eq!(user2.available_funds(&asset_code), 0u64.into());
 
     let (unfreeze_note, freeze_recv_memos, _sig) = freezer
-        .unfreeze_user(rng, &user2.pub_key().address(), 1.into(), &ledger_state.mt)
+        .unfreeze_user(
+            rng,
+            &user2.pub_key().address(),
+            1u64.into(),
+            &ledger_state.mt,
+        )
         .unwrap();
 
     check_freezer_status(&freezer, (native_amount - fee).into(), &user2, 0, 1, 0, 1);
@@ -2416,7 +2421,7 @@ fn example_freeze() {
     );
     assert_eq!(user2.available_funds(&asset_code), non_native_amount);
 
-    assert_eq!(user1.available_funds(&new_asset_code), 0.into());
+    assert_eq!(user1.available_funds(&new_asset_code), 0u64.into());
     user1.scan_block(
         &block,
         &[&freeze_recv_memos, &mint_recv_memos],


### PR DESCRIPTION
## Description

1. Create a `u128` wrapper type `AmountValue` that captures the transfer/fee amount. 
2. Re-implement `CanonicalSerialize` trait for `AmountValue` (the `u128` serialization was missing in Arkworks).
3. Derive numeric trait for `AmountValue` using `derive_more`.
4. Change the circuit so that it accepts any amount with bit length <= 127. (We set to 127 to enable bad path testing on circuit where one can feed a u128 value that overflows 2^127.)
5. Replace `u64` amount variables with `AmountValue` everywhere.
6. unit tests.

closes: #37 
