### PR TITLE
Implement From<Amount> for U256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ sha3 = "^0.10"
 hex-literal = "^0.3"
 serde_json = "1.0.61"
 derive_more = "0.99.17"
-ethabi = "17.0.0"
+primitive-types = "0.11"
 
 # curves
 ark-bls12-381 = { version = "0.3.0", default-features = false, features = ["curve"], optional = true }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -177,11 +177,17 @@ impl CanonicalDeserialize for Amount {
     }
 }
 
-impl TryFrom<ethabi::ethereum_types::U256> for Amount {
+impl From<Amount> for primitive_types::U256 {
+    fn from(amt: Amount) -> Self {
+        u128::from(amt).into()
+    }
+}
+
+impl TryFrom<primitive_types::U256> for Amount {
     type Error = TxnApiError;
 
-    fn try_from(value: ethabi::ethereum_types::U256) -> Result<Self, Self::Error> {
-        if value <= ethabi::ethereum_types::U256::from(u128::MAX) {
+    fn try_from(value: primitive_types::U256) -> Result<Self, Self::Error> {
+        if value <= primitive_types::U256::from(u128::MAX) {
             let mut bytes_u256 = [0u8; 32];
             value.to_little_endian(&mut bytes_u256);
             let mut bytes = [0u8; 16];
@@ -2002,11 +2008,12 @@ mod test {
         assert_eq!(c_amount, c.into());
 
         // Conversion to U256
-        let a = ethabi::ethereum_types::U256::from(u64::MAX);
+        let a = primitive_types::U256::from(u64::MAX);
         assert_eq!(Amount::try_from(a).unwrap(), Amount::from(u64::MAX));
-        let b = ethabi::ethereum_types::U256::from(u64::MAX - 1);
+        let b = primitive_types::U256::from(u64::MAX - 1);
         let b_amount: Amount = b.try_into().unwrap();
         assert_eq!(b_amount, Amount::from(u64::MAX - 1));
+        assert_eq!(b, primitive_types::U256::from(b_amount));
         let c = a * a * b;
         assert!(Amount::try_from(c).is_err());
     }


### PR DESCRIPTION
Leads to less code changes and repetition in the CAPE wallet crate when
switching to 128bit amounts in https://github.com/EspressoSystems/cape/issues/1017.

The U256 type comes from the `primitive_types` crate. As we don't use
anything else from ethabi I think it makes sense to switch the depedency
to primitive_types.

<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
