### PR TITLE
Used espresso-systems-common for tagged_base64 constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ ark-serialize = { version = "0.3.0", default-features = false }
 ark-ec = { version = "0.3.0", default-features = false }
 ark-ff = { version = "0.3.0", default-features = false }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
+espresso-systems-common = { git = "https://github.com/EspressoSystems/espresso-systems-common.git", tag = "0.1.1" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_derive = { version = "1.0", default-features = false }
 itertools = { version = "0.10.1", default-features = false }
-jf-plonk = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
-jf-rescue = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
-jf-primitives = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
-jf-utils = { git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
+jf-plonk = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.2" }
+jf-rescue = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.2" }
+jf-primitives = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.2" }
+jf-utils = { git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.2" }
 sha2 = { version = "0.9.5", default-features = false }
 structopt = { version = "0.3.22", default-features = false }
 rand = { version = "0.8.4", default-features = false, features = [ "alloc" ] }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -39,6 +39,7 @@ use ark_std::{
     vec::Vec,
     UniformRand,
 };
+use espresso_systems_common::cap as tag;
 use jf_primitives::{
     aead, elgamal,
     elgamal::EncKey,
@@ -56,7 +57,7 @@ use jf_utils::{hash_to_field, tagged_blob};
 pub type UserAddress = schnorr::VerKey<CurveParam>;
 
 /// The public key of a `UserKeyPair`
-#[tagged_blob("USERPUBKEY")]
+#[tagged_blob(tag::USERPUBKEY)]
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
 pub struct UserPubKey {
     pub(crate) address: UserAddress,
@@ -123,7 +124,7 @@ impl UserPubKey {
 }
 
 /// A key pair for the user who owns and can consume records (spend asset)
-#[tagged_blob("USERKEY")]
+#[tagged_blob(tag::USERKEY)]
 #[derive(Debug, Default, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct UserKeyPair {
     pub(crate) addr_keypair: schnorr::KeyPair<CurveParam>,
@@ -191,7 +192,7 @@ impl UserKeyPair {
 }
 
 /// Public key for the credential issuer
-#[tagged_blob("CREDPUBKEY")]
+#[tagged_blob(tag::CREDPUBKEY)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default, CanonicalDeserialize, CanonicalSerialize)]
 pub struct CredIssuerPubKey(pub(crate) schnorr::VerKey<CurveParam>);
 
@@ -215,7 +216,7 @@ impl CredIssuerPubKey {
 }
 
 /// Key pair for the credential issuer
-#[tagged_blob("CREDKEY")]
+#[tagged_blob(tag::CREDKEY)]
 #[derive(Debug, Clone, Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct CredIssuerKeyPair(pub(crate) schnorr::KeyPair<CurveParam>);
 
@@ -243,7 +244,7 @@ impl CredIssuerKeyPair {
 }
 
 /// Public key for the auditor
-#[tagged_blob("AUDPUBKEY")]
+#[tagged_blob(tag::AUDPUBKEY)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default, CanonicalDeserialize, CanonicalSerialize)]
 pub struct AuditorPubKey(pub(crate) elgamal::EncKey<CurveParam>);
 
@@ -270,7 +271,7 @@ impl AuditorPubKey {
     }
 }
 /// Key pair for the auditor
-#[tagged_blob("AUDKEY")]
+#[tagged_blob(tag::AUDKEY)]
 #[derive(Debug, Clone, CanonicalDeserialize, CanonicalSerialize)]
 pub struct AuditorKeyPair(pub(crate) elgamal::KeyPair<CurveParam>);
 
@@ -367,7 +368,7 @@ impl AuditorKeyPair {
 }
 
 /// Public key for the freezer
-#[tagged_blob("FREEZEPUBKEY")]
+#[tagged_blob(tag::FREEZEPUBKEY)]
 #[derive(Clone, Debug, Eq, Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct FreezerPubKey(pub(crate) GroupProjective<CurveParam>);
 
@@ -392,7 +393,7 @@ impl PartialEq for FreezerPubKey {
 }
 
 /// Key pair for the freezer
-#[tagged_blob("FREEZEKEY")]
+#[tagged_blob(tag::FREEZEKEY)]
 #[derive(Clone, Debug, Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct FreezerKeyPair {
     pub(crate) sec_key: ScalarField,
@@ -468,7 +469,7 @@ fn compute_nullifier_key(
 
 /// Secret key used to nullify records, can only be derived by either the record
 /// owner (`UserKeyPair`) or the correct freezer (`FreezerKeyPair`)
-#[tagged_blob("NULKEY")]
+#[tagged_blob(tag::NULKEY)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
 pub(crate) struct NullifierKey(pub(crate) BaseField);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@ use crate::{
 use ark_serialize::*;
 use ark_std::{boxed::Box, format, string::ToString, vec, vec::Vec};
 use errors::TxnApiError;
+use espresso_systems_common::cap as tag;
 use freeze::FreezeNote;
 use jf_plonk::{proof_system::structs::Proof, transcript::SolidityTranscript};
 use jf_primitives::signatures::{schnorr::SchnorrSignatureScheme, SignatureScheme};
@@ -360,7 +361,7 @@ impl From<FreezeNote> for TransactionNote {
 
 /// A transaction verifying key contains a proof verification key of possibly
 /// various transaction types, including transfer, mint and freeze.
-#[tagged_blob("TXVERKEY")]
+#[tagged_blob(tag::TXVERKEY)]
 #[derive(Debug, Clone)]
 pub enum TransactionVerifyingKey {
     /// verification key for validity proof in transfer note

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -31,6 +31,7 @@ use ark_std::{
     vec,
     vec::Vec,
 };
+use espresso_systems_common::cap as tag;
 use jf_primitives::{
     aead,
     commitment::Commitment as RescueCommitment,
@@ -55,14 +56,14 @@ pub enum NoteType {
 }
 
 /// A unique identifier/code for an asset type
-#[tagged_blob("INTERNAL_ASSET_CODE")]
+#[tagged_blob(tag::INTERNAL_ASSET_CODE)]
 #[derive(
     Debug, Clone, Copy, PartialEq, Default, CanonicalSerialize, CanonicalDeserialize, Hash, Eq,
 )]
 pub struct InternalAssetCode(pub(crate) BaseField);
 
 /// The random seed used in AssetCode derivation
-#[tagged_blob("ASSET_SEED")]
+#[tagged_blob(tag::ASSET_SEED)]
 #[derive(Debug, Copy, Clone, Default, CanonicalSerialize, CanonicalDeserialize, PartialEq)]
 pub struct AssetCodeSeed(pub(crate) BaseField);
 
@@ -203,7 +204,7 @@ impl TryFrom<primitive_types::U256> for Amount {
 }
 
 /// Asset code structure
-#[tagged_blob("ASSET_CODE")]
+#[tagged_blob(tag::ASSET_CODE)]
 #[derive(
     Debug, Clone, Copy, PartialEq, Default, CanonicalSerialize, CanonicalDeserialize, Hash, Eq,
 )]
@@ -691,7 +692,7 @@ impl AssetPolicy {
 /// Asset Definition
 /// * `code` -- asset code as unique id code
 /// * `policy` -- asset policy attached
-#[tagged_blob("ASSET_DEF")]
+#[tagged_blob(tag::ASSET_DEF)]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Default, CanonicalDeserialize, CanonicalSerialize)]
 pub struct AssetDefinition {
     /// asset code as unique id code
@@ -750,7 +751,7 @@ impl AssetDefinition {
 pub(crate) type CommitmentValue = BaseField;
 
 /// The blind factor used to produce a hiding commitment
-#[tagged_blob("BLIND")]
+#[tagged_blob(tag::BLIND)]
 #[derive(
     Copy, Clone, Debug, Default, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize,
 )]
@@ -773,7 +774,7 @@ impl From<BaseField> for BlindFactor {
 }
 
 /// The nullifier represents a spent/consumed asset record
-#[tagged_blob("NUL")]
+#[tagged_blob(tag::NUL)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Nullifier(pub(crate) BaseField);
 
@@ -788,7 +789,7 @@ impl Nullifier {
 }
 
 /// Asset record to be published
-#[tagged_blob("REC")]
+#[tagged_blob(tag::REC)]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, CanonicalSerialize, CanonicalDeserialize)]
 pub struct RecordCommitment(pub(crate) CommitmentValue);
 
@@ -1010,13 +1011,13 @@ impl RecordOpening {
 }
 
 // The actual credential which is basically a Schnorr signature over attributes
-#[tagged_blob("CRED")]
+#[tagged_blob(tag::CRED)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
 pub(crate) struct Credential(pub(crate) Signature);
 
 /// An identity attribute of a user, usually attested via `ExpirableCredential`
 /// issued by an identity issuer.
-#[tagged_blob("ID")]
+#[tagged_blob(tag::ID)]
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
 pub struct IdentityAttribute(pub(crate) BaseField);
 
@@ -1199,7 +1200,7 @@ impl ExpirableCredential {
 /// Memos for auditors such as auditors required by the asset policy.
 /// Concretely, it is a ciphertext over details of a
 /// transaction, enabling asset tracing and identity tracing.
-#[tagged_blob("AUDMEMO")]
+#[tagged_blob(tag::AUDMEMO)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
 pub struct AuditMemo(pub(crate) elgamal::Ciphertext<CurveParam>);
 
@@ -1507,7 +1508,7 @@ impl AuditData {
 }
 // TODO: (alex) add this after Philippe's MT MR merged
 /// The proof of membership in an accumulator (Merkle tree) for an asset record
-#[tagged_blob("RECMEMO")]
+#[tagged_blob(tag::RECMEMO)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
 /// Encrypted Message for owners of transaction outputs
 pub struct ReceiverMemo(pub(crate) aead::Ciphertext);


### PR DESCRIPTION
<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

As discussed in zulip, we want to make sure we don't have conflicting `tagged-base64` tags. For this I've made [espresso-systems-common](https://github.com/EspressoSystems/espresso-systems-common)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
