### PR TITLE
add prelude module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -583,6 +583,25 @@ pub fn sign_receiver_memos(
     Ok(keypair.sign(&[digest], SchnorrSignatureScheme::<CurveParam>::CS_ID))
 }
 
+/// crate prelude consisting important traits and structs
+pub mod preclude {
+    pub use super::{
+        calculate_fee, derive_txns_fee_records, sign_receiver_memos, TransactionNote,
+        TransactionVerifyingKey,
+    };
+    pub use crate::{
+        constants::*,
+        errors::*,
+        freeze::*,
+        keys::*,
+        mint::*,
+        proof::universal_setup_for_staging,
+        structs::*,
+        transfer::{AuxInfo as TransferNoteAuxInfo, TransferNote, TransferNoteInput},
+        types::*,
+    };
+}
+
 #[cfg(test)]
 mod test {
     use crate::{


### PR DESCRIPTION
## Description

Add a `prelude` module so that downstream libraries can have a much succinct import in most cases: `use jf_cap::prelude::*;`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] ~Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.~
- [ ] ~Wrote unit tests!~
- [x] Updated relevant documentation in the code
- [ ] ~Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`~
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
