### PR TITLE
Remove itertools dependency, better no_std support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+- Removed `itertools` dependency, replace `HashMap` with `BTreeMap` (#60)
+
 ### Breaking changes
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ ark-ff = { version = "0.3.0", default-features = false }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_derive = { version = "1.0", default-features = false }
-itertools = { version = "0.10.1", default-features = false }
 jf-plonk = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
 jf-rescue = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
 jf-primitives = { features=["std"], git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.1.1" }
@@ -51,7 +50,6 @@ ark-ed-on-bn254 = { version = "0.3.0", default-features = false, optional = true
 
 [dev-dependencies]
 criterion = "0.3.1"
-itertools = "^0.10.1"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 
@@ -77,6 +75,6 @@ default = [ "bn254" ]
 bls12_381 = [ "ark-bls12-381", "ark-ed-on-bls12-381" ]
 bls12_377 = [ "ark-bls12-377", "ark-ed-on-bls12-377" ]
 bn254 = [ "ark-bn254", "ark-ed-on-bn254" ]
-std = []
+std = [ "ark-std/std" ]
 # exposing apis for testing purpose
 test_apis = []

--- a/benches/batch_verification.rs
+++ b/benches/batch_verification.rs
@@ -34,7 +34,7 @@ fn run_batch_verification(
     roots: &[NodeValue],
     timestamp: u64,
 ) {
-    let verify_keys = verify_keys.iter().map(|x| x).collect_vec();
+    let verify_keys: Vec<_> = verify_keys.iter().map(|x| x).collect();
     assert!(txn_batch_verify(notes, roots, timestamp, &verify_keys).is_ok());
 }
 

--- a/benches/batch_verification.rs
+++ b/benches/batch_verification.rs
@@ -13,7 +13,6 @@
 extern crate criterion;
 
 use criterion::Criterion;
-use itertools::Itertools;
 use jf_cap::{
     bench_utils::{
         compute_title_batch, get_builder_freeze, get_builder_mint, get_builder_transfer,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -205,7 +205,17 @@ impl TryFrom<primitive_types::U256> for Amount {
 /// Asset code structure
 #[tagged_blob("ASSET_CODE")]
 #[derive(
-    Debug, Clone, Copy, PartialEq, Default, CanonicalSerialize, CanonicalDeserialize, Hash, Eq,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Default,
+    CanonicalSerialize,
+    CanonicalDeserialize,
+    Hash,
+    Eq,
 )]
 pub struct AssetCode(pub(crate) BaseField);
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -774,7 +774,18 @@ impl From<BaseField> for BlindFactor {
 
 /// The nullifier represents a spent/consumed asset record
 #[tagged_blob("NUL")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    CanonicalSerialize,
+    CanonicalDeserialize,
+)]
 pub struct Nullifier(pub(crate) BaseField);
 
 impl Nullifier {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -287,13 +287,12 @@ pub(crate) mod txn_helpers {
     };
     use ark_serialize::CanonicalSerialize;
     use ark_std::{
-        collections::HashMap,
+        collections::{BTreeSet, HashMap},
         format,
         string::{String, ToString},
         vec,
         vec::Vec,
     };
-    use itertools::Itertools;
     use jf_primitives::merkle_tree::{MerkleLeaf, MerkleLeafProof, MerkleTree};
     use jf_utils::hash_to_field;
     use rand::{CryptoRng, RngCore};
@@ -301,7 +300,8 @@ pub(crate) mod txn_helpers {
     pub(crate) fn check_distinct_input_nullifiers(
         nullifiers: &[Nullifier],
     ) -> Result<(), TxnApiError> {
-        if nullifiers.iter().all_unique() {
+        let mut seen = BTreeSet::new();
+        if nullifiers.iter().all(|nf| seen.insert(*nf)) {
             Ok(())
         } else {
             Err(TxnApiError::InvalidParameter(

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -287,7 +287,7 @@ pub(crate) mod txn_helpers {
     };
     use ark_serialize::CanonicalSerialize;
     use ark_std::{
-        collections::{BTreeSet, HashMap},
+        collections::{BTreeMap, BTreeSet},
         format,
         string::{String, ToString},
         vec,
@@ -711,7 +711,7 @@ pub(crate) mod txn_helpers {
         outputs: &[&RecordOpening],
         fee: Amount,
     ) -> Result<(), TxnApiError> {
-        let mut balances = HashMap::new();
+        let mut balances = BTreeMap::new();
 
         let native_ac = inputs[0].asset_def.code; // assume already checked first is native
         balances.insert(native_ac, -(fee.0 as i128));


### PR DESCRIPTION
## Description

Changes include
- remove dependency on `itertools` to resolve downstream libraries compilation problem
- Remove any use of `HashSet/Map` for better `no_std` support

closes: #59 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] ~Wrote unit tests~
- [x] ~Updated relevant documentation in the code~
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] ~Re-reviewed `Files changed` in the GitHub PR explorer~
