### PR TITLE
Make `UserAddress` a newtype with its own tagged blob impl

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1367,7 +1367,7 @@ impl ViewableData {
         x: &BaseField,
         y: &BaseField,
         asset_definition: &AssetDefinition,
-    ) -> Result<Option<VerKey>, TxnApiError> {
+    ) -> Result<Option<UserAddress>, TxnApiError> {
         let point_affine = GroupAffine::<CurveParam>::new(*x, *y);
         if !point_affine.is_on_curve() || !point_affine.is_in_correct_subgroup_assuming_on_curve() {
             if asset_definition
@@ -1385,7 +1385,7 @@ impl ViewableData {
 
         let ver_key = VerKey::from(point_affine);
         if asset_definition.policy.is_user_address_revealed() || ver_key == VerKey::default() {
-            Ok(Some(ver_key))
+            Ok(Some(ver_key.into()))
         } else {
             Ok(None)
         }


### PR DESCRIPTION
We've almost entirely gotten rid of EspressoSystems/net as a dependency, replacing it with EspressoSystems/tide-disco. The last piece of `net` that is still in use is a `UserAddress` newtype that adds tagged blob. This is error prone anyways, because we always need to remember to convert `jf_cap::UserAddress` to `net::UserAddress` before printing or serializing, otherwise we'll get the `VerKey` impls. Rather than port this problematic hack to tide-disco, it's better to just upstream it into CAP so that `jf_cap::UserAddress` will be the only address type we use everywhere, and will have the correct serialize and display impls. Then we can finally archive `net`.

<!---
Credit: Arkworks project https://github.com/arkworks-rs/
-->

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
